### PR TITLE
feature/PP-171

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.2-alpha.4",
   "description": "This project contains all the client code for the rif relay system.",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@rsksmart/rif-relay-contracts": "0.0.2-alpha.4",
-    "@rsksmart/rif-relay-common": "0.0.2-alpha.4",
+    "@rsksmart/rif-relay-common": "0.0.2-alpha.5",
     "abi-decoder": "~2.3.0",
     "axios": "~0.21.1",
     "eth-sig-util": "2.5.2",

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -65,6 +65,7 @@ export interface RelayingAttempt {
 
 export interface RelayingResult {
     transaction?: Transaction;
+    receipt?: TransactionReceipt;
     pingErrors: Map<string, Error>;
     relayingErrors: Map<string, Error>;
 }

--- a/src/RelayProvider.ts
+++ b/src/RelayProvider.ts
@@ -336,10 +336,10 @@ export default class RelayProvider implements HttpProvider {
         );
     }
 
-    async _ethSendTransaction(
+    _ethSendTransaction(
         payload: JsonRpcPayload,
         callback: JsonRpcCallback
-    ): Promise<void> {
+    ): void {
         log.info('calling sendAsync' + JSON.stringify(payload));
         log.debug('Relay Provider - _ethSendTransaction called');
         let transactionDetails: EnvelopingTransactionDetails =
@@ -399,13 +399,16 @@ export default class RelayProvider implements HttpProvider {
             `Relay Provider - callForwarder: ${transactionDetails.callForwarder}`
         );
 
-        const relayingResult: RelayingResult =
-            await this.executeRelayTransaction(transactionDetails);
-        const jsonRpcSendResult = this._convertTransactionToRpcSendResponse(
-            relayingResult,
-            payload
+        this.executeRelayTransaction(transactionDetails).then(
+            (relayingResult: RelayingResult) => {
+                const jsonRpcSendResult =
+                    this._convertTransactionToRpcSendResponse(
+                        relayingResult,
+                        payload
+                    );
+                callback(null, jsonRpcSendResult);
+            }
         );
-        callback(null, jsonRpcSendResult);
     }
 
     async processTransactionReceipt(

--- a/src/RelayProvider.ts
+++ b/src/RelayProvider.ts
@@ -15,7 +15,6 @@ import {
     constants
 } from '@rsksmart/rif-relay-common';
 import { configure, EnvelopingDependencies } from './Configurator';
-import { Transaction } from 'ethereumjs-tx';
 import { AccountKeypair } from './AccountManager';
 import { RelayEvent } from './RelayEvents';
 import { Address } from './types/Aliases';

--- a/src/RelayProvider.ts
+++ b/src/RelayProvider.ts
@@ -366,8 +366,7 @@ export default class RelayProvider implements HttpProvider {
 
     _ethSendTransaction(
         payload: JsonRpcPayload,
-        callback: JsonRpcCallback,
-        nonBlock?: boolean
+        callback: JsonRpcCallback
     ): void {
         log.info('calling sendAsync' + JSON.stringify(payload));
         log.debug('Relay Provider - _ethSendTransaction called');
@@ -434,14 +433,7 @@ export default class RelayProvider implements HttpProvider {
                     relayingResult.transaction !== undefined &&
                     relayingResult.transaction !== null
                 ) {
-                    if (nonBlock) {
-                        const jsonRpcSendResult =
-                            this._convertTransactionToRpcSendResponse(
-                                relayingResult.transaction,
-                                payload
-                            );
-                        callback(null, jsonRpcSendResult);
-                    } else {
+                    if (transactionDetails.waitForTransactionReceipt) {
                         const txHash =
                             '0x' +
                             relayingResult.transaction
@@ -512,6 +504,13 @@ export default class RelayProvider implements HttpProvider {
                                     );
                                 }
                             );
+                    } else {
+                        const jsonRpcSendResult =
+                            this._convertTransactionToRpcSendResponse(
+                                relayingResult.transaction,
+                                payload
+                            );
+                        callback(null, jsonRpcSendResult);
                     }
                 } else {
                     const message = `Failed to relay call. Results:\n${_dumpRelayingResult(

--- a/src/RelayProvider.ts
+++ b/src/RelayProvider.ts
@@ -433,69 +433,12 @@ export default class RelayProvider implements HttpProvider {
                     relayingResult.transaction !== undefined &&
                     relayingResult.transaction !== null
                 ) {
-                    const txHash =
-                        '0x' +
-                        relayingResult.transaction.hash(true).toString('hex');
-                    const { retries, initialBackoff } = transactionDetails;
-                    this.relayClient
-                        .getTransactionReceipt(txHash, retries, initialBackoff)
-                        .then(
-                            (receipt) => {
-                                const relayStatus =
-                                    this._getRelayStatus(receipt);
-
-                                if (
-                                    relayingResult.transaction === undefined ||
-                                    relayingResult.transaction === null
-                                ) {
-                                    // Imposible scenario, but we addded it so the linter does not complain since it wont allow using ! keyword
-                                    callback(
-                                        new Error(
-                                            `Unknown Runtime error while processing result of txHash: ${txHash}`
-                                        )
-                                    );
-                                } else {
-                                    if (relayStatus.transactionRelayed) {
-                                        const jsonRpcSendResult =
-                                            this._convertTransactionToRpcSendResponse(
-                                                relayingResult.transaction,
-                                                payload
-                                            );
-                                        callback(null, jsonRpcSendResult);
-                                    } else if (
-                                        relayStatus.relayRevertedOnRecipient
-                                    ) {
-                                        callback(
-                                            new Error(
-                                                `Transaction Relayed but reverted on recipient - TxHash: ${txHash} , Reason: ${relayStatus.reason}`
-                                            )
-                                        );
-                                    } else {
-                                        const jsonRpcSendResult =
-                                            this._convertTransactionToRpcSendResponse(
-                                                relayingResult.transaction,
-                                                payload
-                                            );
-                                        callback(null, jsonRpcSendResult);
-                                    }
-                                }
-                            },
-                            (error) => {
-                                const reasonStr =
-                                    error instanceof Error
-                                        ? error.message
-                                        : JSON.stringify(error);
-                                log.info(
-                                    'Error while fetching transaction receipt',
-                                    error
-                                );
-                                callback(
-                                    new Error(
-                                        `Rejected relayTransaction call - Reason: ${reasonStr}`
-                                    )
-                                );
-                            }
+                    const jsonRpcSendResult =
+                        this._convertTransactionToRpcSendResponse(
+                            relayingResult.transaction,
+                            payload
                         );
+                    callback(null, jsonRpcSendResult);
                 } else {
                     const message = `Failed to relay call. Results:\n${_dumpRelayingResult(
                         relayingResult

--- a/src/RelayProvider.ts
+++ b/src/RelayProvider.ts
@@ -433,12 +433,69 @@ export default class RelayProvider implements HttpProvider {
                     relayingResult.transaction !== undefined &&
                     relayingResult.transaction !== null
                 ) {
-                    const jsonRpcSendResult =
-                        this._convertTransactionToRpcSendResponse(
-                            relayingResult.transaction,
-                            payload
+                    const txHash =
+                        '0x' +
+                        relayingResult.transaction.hash(true).toString('hex');
+                    const { retries, initialBackoff } = transactionDetails;
+                    this.relayClient
+                        .getTransactionReceipt(txHash, retries, initialBackoff)
+                        .then(
+                            (receipt) => {
+                                const relayStatus =
+                                    this._getRelayStatus(receipt);
+
+                                if (
+                                    relayingResult.transaction === undefined ||
+                                    relayingResult.transaction === null
+                                ) {
+                                    // Imposible scenario, but we addded it so the linter does not complain since it wont allow using ! keyword
+                                    callback(
+                                        new Error(
+                                            `Unknown Runtime error while processing result of txHash: ${txHash}`
+                                        )
+                                    );
+                                } else {
+                                    if (relayStatus.transactionRelayed) {
+                                        const jsonRpcSendResult =
+                                            this._convertTransactionToRpcSendResponse(
+                                                relayingResult.transaction,
+                                                payload
+                                            );
+                                        callback(null, jsonRpcSendResult);
+                                    } else if (
+                                        relayStatus.relayRevertedOnRecipient
+                                    ) {
+                                        callback(
+                                            new Error(
+                                                `Transaction Relayed but reverted on recipient - TxHash: ${txHash} , Reason: ${relayStatus.reason}`
+                                            )
+                                        );
+                                    } else {
+                                        const jsonRpcSendResult =
+                                            this._convertTransactionToRpcSendResponse(
+                                                relayingResult.transaction,
+                                                payload
+                                            );
+                                        callback(null, jsonRpcSendResult);
+                                    }
+                                }
+                            },
+                            (error) => {
+                                const reasonStr =
+                                    error instanceof Error
+                                        ? error.message
+                                        : JSON.stringify(error);
+                                log.info(
+                                    'Error while fetching transaction receipt',
+                                    error
+                                );
+                                callback(
+                                    new Error(
+                                        `Rejected relayTransaction call - Reason: ${reasonStr}`
+                                    )
+                                );
+                            }
                         );
-                    callback(null, jsonRpcSendResult);
                 } else {
                     const message = `Failed to relay call. Results:\n${_dumpRelayingResult(
                         relayingResult


### PR DESCRIPTION
## What

- Created a transaction history modal to be able to verify the transactions for each smart wallet

## Why

- With the current implementation, each time the users try to execute a transaction, they need to wait until it is confirmed (or rejected). To avoid this, we could provide the user with the link to the explorer.

## Refs

- [Jira issue](https://rsklabs.atlassian.net/browse/PP-171)
- https://github.com/rsksmart/rif-relay-common/pull/23