### PR TITLE
PP-127: no-collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     ]
   },
   "dependencies": {
-    "@rsksmart/rif-relay-common": "file:../rif-relay-common",
-    "@rsksmart/rif-relay-contracts": "file:../rif-relay-contracts",
+    "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-127/no-collector-field",
+    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/optional-collector",
     "abi-decoder": "~2.3.0",
     "axios": "~0.21.1",
     "eth-sig-util": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     ]
   },
   "dependencies": {
-    "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-127/no-collector-field",
-    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/optional-collector",
+    "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-94/revenue-sharing-model",
+    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
     "abi-decoder": "~2.3.0",
     "axios": "~0.21.1",
     "eth-sig-util": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     ]
   },
   "dependencies": {
-    "@rsksmart/rif-relay-common": "https://github.com/rsksmart/rif-relay-common#PP-94/revenue-sharing-model",
-    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
+    "@rsksmart/rif-relay-common": "file:../rif-relay-common",
+    "@rsksmart/rif-relay-contracts": "file:../rif-relay-contracts",
     "abi-decoder": "~2.3.0",
     "axios": "~0.21.1",
     "eth-sig-util": "2.5.2",

--- a/src/Enveloping.ts
+++ b/src/Enveloping.ts
@@ -42,13 +42,15 @@ export interface SignatureProvider {
 export default class Enveloping {
     config: EnvelopingConfig;
     relayWorkerAddress: Address;
+    feesReceiver: Address;
     dependencies: EnvelopingDependencies;
     private initialized: boolean;
 
     constructor(
         _config: EnvelopingConfig,
         _web3: Web3,
-        _relayWorkerAddress: Address
+        _relayWorkerAddress: Address,
+        _feesReceiver: Address
     ) {
         this.config = _config;
         this.initialized = false;
@@ -57,6 +59,7 @@ export default class Enveloping {
             _web3.currentProvider as HttpProvider
         );
         this.relayWorkerAddress = _relayWorkerAddress;
+        this.feesReceiver = _feesReceiver;
     }
 
     async _init(): Promise<void> {
@@ -109,7 +112,7 @@ export default class Enveloping {
             },
             relayData: {
                 gasPrice: gasPrice ?? (await web3.eth.getGasPrice()),
-                relayWorker: this.relayWorkerAddress,
+                feesReceiver: this.feesReceiver,
                 callForwarder: this.config.smartWalletFactoryAddress,
                 callVerifier: this.config.deployVerifierAddress
             }
@@ -197,13 +200,12 @@ export default class Enveloping {
                 gas: gasToSend,
                 nonce: (await this.getSenderNonce(forwarder)).toString(),
                 tokenContract: tokenContract,
-                collectorContract: collectorContract ?? zeroAddr,
                 tokenAmount: tokenAmount,
                 tokenGas: tokenGas
             },
             relayData: {
                 gasPrice: gasPriceToSend,
-                relayWorker: this.relayWorkerAddress,
+                feesReceiver: this.feesReceiver,
                 callForwarder: forwarder,
                 callVerifier: this.config.relayVerifierAddress
             }

--- a/src/Enveloping.ts
+++ b/src/Enveloping.ts
@@ -173,7 +173,7 @@ export default class Enveloping {
         tokenAmount: IntString,
         tokenGas: IntString,
         gasLimit?: IntString,
-        gasPrice?: IntString,
+        gasPrice?: IntString
     ): Promise<RelayRequest> {
         let gasToSend = gasLimit;
         const gasPriceToSend = gasPrice ?? (await web3.eth.getGasPrice());

--- a/src/Enveloping.ts
+++ b/src/Enveloping.ts
@@ -174,7 +174,6 @@ export default class Enveloping {
         tokenGas: IntString,
         gasLimit?: IntString,
         gasPrice?: IntString,
-        collectorContract?: Address
     ): Promise<RelayRequest> {
         let gasToSend = gasLimit;
         const gasPriceToSend = gasPrice ?? (await web3.eth.getGasPrice());

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -303,7 +303,8 @@ export class RelayClient {
             const estimated =
                 (await this.calculateSmartWalletRelayGas(
                     trxDetails,
-                    relayWorkerAddress
+                    relayWorkerAddress,
+                    feesReceiver
                 )) + Number(trxDetails.tokenGas);
             maxPossibleGas = toBN(
                 Math.ceil(estimated * constants.ESTIMATED_GAS_CORRECTION_FACTOR)
@@ -335,7 +336,8 @@ export class RelayClient {
     // The tokenGas must be added to this result in order to get the full estimate
     async calculateSmartWalletRelayGas(
         transactionDetails: EnvelopingTransactionDetails,
-        relayWorker: string
+        relayWorker: string,
+        feesReceiver: string
     ): Promise<number> {
         const testInfo = await this._prepareRelayHttpRequest(
             {
@@ -343,7 +345,7 @@ export class RelayClient {
                     relayWorkerAddress: relayWorker,
                     relayManagerAddress: constants.ZERO_ADDRESS,
                     relayHubAddress: constants.ZERO_ADDRESS,
-                    feesReceiver: constants.ZERO_ADDRESS,
+                    feesReceiver,
                     minGasPrice: '0',
                     ready: true,
                     version: ''

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -203,13 +203,12 @@ export class RelayClient {
      * It has the advantage of not requiring the user to sign the transaction in the relay calls
      * If the transaction details are for a deploy, it won't use a linear fit
      * @param transactionDetails
-     * @param relayWorker
      * @returns maxPossibleGas: The maximum expected gas to be used by the transaction
      */
     async estimateMaxPossibleRelayGasWithLinearFit(
         transactionDetails: EnvelopingTransactionDetails
     ): Promise<number> {
-        const { collectorAddress, relayWorkerAddress } =
+        const { feesReceiver, relayWorkerAddress } =
             await this.getPingResponse();
         const trxDetails = { ...transactionDetails };
         trxDetails.gasPrice =
@@ -232,7 +231,7 @@ export class RelayClient {
             trxDetails.gas = '0x00';
             const testRequest = await this._prepareFactoryGasEstimationRequest(
                 trxDetails,
-                collectorAddress
+                feesReceiver
             );
             deployCallEstimate =
                 (await this.calculateDeployCallGas(
@@ -266,13 +265,12 @@ export class RelayClient {
     /**
      * Can be used to get an estimate of the maximum possible gas to be used by the transaction
      * @param transactionDetails
-     * @param feesReceiver
      * @returns maxPossibleGas: The maximum expected gas to be used by the transaction
      */
     async estimateMaxPossibleRelayGas(
         transactionDetails: EnvelopingTransactionDetails
     ): Promise<number> {
-        const { collectorAddress, relayWorkerAddress } =
+        const { feesReceiver, relayWorkerAddress } =
             await this.getPingResponse();
         const trxDetails = { ...transactionDetails };
         trxDetails.gasPrice =
@@ -290,7 +288,7 @@ export class RelayClient {
             trxDetails.gas = '0x00';
             const testRequest = await this._prepareFactoryGasEstimationRequest(
                 trxDetails,
-                collectorAddress
+                feesReceiver
             );
             deployCallEstimate =
                 (await this.calculateDeployCallGas(
@@ -345,6 +343,7 @@ export class RelayClient {
                     relayWorkerAddress: relayWorker,
                     relayManagerAddress: constants.ZERO_ADDRESS,
                     relayHubAddress: constants.ZERO_ADDRESS,
+                    feesReceiver: constants.ZERO_ADDRESS,
                     minGasPrice: '0',
                     ready: true,
                     version: ''
@@ -445,7 +444,7 @@ export class RelayClient {
     async estimateTokenTransferGas(
         transactionDetails: EnvelopingTransactionDetails
     ): Promise<number> {
-        const { collectorAddress } = await this.getPingResponse();
+        const { feesReceiver } = await this.getPingResponse();
         let gasCost = 0;
         const tokenContract =
             transactionDetails.tokenContract ?? constants.ZERO_ADDRESS;
@@ -474,7 +473,7 @@ export class RelayClient {
 
             if (tokenOrigin !== constants.ZERO_ADDRESS) {
                 const transferParams = [
-                    collectorAddress,
+                    feesReceiver,
                     transactionDetails.tokenAmount ?? '0'
                 ];
                 log.debug(
@@ -773,11 +772,10 @@ export class RelayClient {
                 forwarderAddress,
                 transactionDetails.from
             );
-        log.info({ senderNonce });
         const callVerifier =
             transactionDetails.callVerifier ??
             this.config.deployVerifierAddress;
-        const { relayWorkerAddress, collectorAddress } = relayInfo.pingResponse;
+        const { relayWorkerAddress, feesReceiver } = relayInfo.pingResponse;
         const gasPriceHex = transactionDetails.gasPrice;
         if (gasPriceHex == null) {
             throw new Error(
@@ -811,7 +809,7 @@ export class RelayClient {
                 gasPrice,
                 callVerifier,
                 callForwarder: forwarderAddress,
-                feesReceiver: collectorAddress
+                feesReceiver
             }
         };
         this.emit(new SignRequestEvent());
@@ -867,7 +865,7 @@ export class RelayClient {
         const gasPrice = parseInt(gasPriceHex, 16).toString();
         const value = transactionDetails.value ?? '0';
 
-        const feesReceiver = relayInfo.pingResponse.collectorAddress;
+        const { feesReceiver } = relayInfo.pingResponse;
         const relayRequest: RelayRequest = {
             request: {
                 relayHub: transactionDetails.relayHub ?? constants.ZERO_ADDRESS,

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -944,8 +944,7 @@ export class RelayClient {
     }
 
     private async getPingResponse() {
-        const { url } = this.knownRelaysManager.preferredRelayers[0];
-        return this.httpClient.getPingResponse(url);
+        return this.httpClient.getPingResponse(this.config.preferredRelays[0]);
     }
 }
 

--- a/src/RelayedTransactionValidator.ts
+++ b/src/RelayedTransactionValidator.ts
@@ -29,7 +29,8 @@ export default class RelayedTransactionValidator {
      */
     validateRelayResponse(
         request: RelayTransactionRequest | DeployTransactionRequest,
-        returnedTx: PrefixedHexString
+        returnedTx: PrefixedHexString,
+        relayWorker: string
     ): boolean {
         const transaction = new Transaction(
             returnedTx,
@@ -73,7 +74,7 @@ export default class RelayedTransactionValidator {
                 this.config.relayHubAddress
             ) &&
             relayRequestAbiEncode === bufferToHex(transaction.data) &&
-            isSameAddress(request.relayRequest.relayData.relayWorker, signer)
+            isSameAddress(relayWorker, signer)
         ) {
             log.info('validateRelayResponse - valid transaction response');
 
@@ -101,7 +102,7 @@ export default class RelayedTransactionValidator {
                 'validateRelayResponse: req',
                 relayRequestAbiEncode,
                 this.config.relayHubAddress,
-                request.relayRequest.relayData.relayWorker
+                request.relayRequest.relayData.feesReceiver
             );
             console.error(
                 'validateRelayResponse: rsp',


### PR DESCRIPTION
## What

- removed collector fields
- relay worker removed from transaction details
- added methods to call ping handler
- collector contract and relay worker are now obtained by pinging the server

## Why

- There is no reason why anyone that uses the client should have to specify the collector contract, or even the relay worker since the rif-relay setup is confirmed to be single tenant.

## Refs

- PP-91, PP-127
