### PR TITLE
PP-570/pricer-case-sensitive

### DIFF
--- a/src/RelayPricer.ts
+++ b/src/RelayPricer.ts
@@ -14,8 +14,9 @@ const EXCHANGE_APIS: BaseExchangeApi[] = [coinbase, testExchange, rdocExchange];
 
 export default class RelayPricer {
     findAvailableApi(token: string): BaseExchangeApi {
+        const upperCaseToken = token?.toUpperCase();
         const availableApi = EXCHANGE_APIS.find((api) =>
-            api.tokens.includes(token)
+            api.tokens.includes(upperCaseToken)
         );
 
         if (!availableApi) {

--- a/src/api/CoinBase.ts
+++ b/src/api/CoinBase.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import BigNumber from 'bignumber.js';
-import BaseExchangeApi from './ExchangeApi';
+import BaseExchangeApi, { CurrencyMapping } from './ExchangeApi';
 import log, { LogLevelDesc } from 'loglevel';
 
 const URL = 'https://api.coinbase.com/v2/exchange-rates';
@@ -21,9 +21,10 @@ export type CoinBaseErrorResponse = {
     errors: Array<CoinBaseError>;
 };
 
-const CURRENCY_MAPPING: Record<string, string> = {
+const CURRENCY_MAPPING: CurrencyMapping = {
     RIF: 'RIF',
-    RBTC: 'RBTC'
+    RBTC: 'RBTC',
+    TRIF: 'RIF'
 };
 
 /* TODO:
@@ -62,7 +63,7 @@ export default class CoinBase extends BaseExchangeApi {
     private readonly _httpClient: AxiosInstance;
 
     constructor(loglLevel: LogLevelDesc = 'error') {
-        super('CoinBase', CURRENCY_MAPPING, ['RIF', 'RBTC']);
+        super('CoinBase', CURRENCY_MAPPING, ['RIF', 'RBTC', 'tRif']);
         log.setLevel(loglLevel);
 
         this._httpClient = axios.create();

--- a/src/api/ExchangeApi.ts
+++ b/src/api/ExchangeApi.ts
@@ -1,11 +1,21 @@
 import BigNumber from 'bignumber.js';
 
+const avialableCurrencies = ['TRIF', 'RIF', 'RDOC', 'RBTC', 'TKN'] as const;
+
+export type FromCurrency = typeof avialableCurrencies[number];
+
+export type CurrencyMapping = Partial<Record<FromCurrency, string>>;
+
 export default abstract class BaseExchangeApi {
+    public readonly tokens: string[];
+
     constructor(
         protected readonly api: string,
-        private currencyMapping: Record<string, string>,
-        public readonly tokens: string[]
-    ) {}
+        private currencyMapping: CurrencyMapping,
+        tokens: string[]
+    ) {
+        this.tokens = tokens.map((token) => token.toUpperCase());
+    }
 
     getApiTokenName(tokenSymbol: string): string {
         if (!tokenSymbol) {
@@ -13,14 +23,19 @@ export default abstract class BaseExchangeApi {
                 `${this.api} API cannot map a token with a null/empty value`
             );
         }
+
         const upperCaseTokenSymbol = tokenSymbol.toUpperCase();
-        const resultMapping = this.currencyMapping[upperCaseTokenSymbol];
-        if (!resultMapping) {
+
+        const currency = avialableCurrencies.find(
+            (c) => c === upperCaseTokenSymbol
+        );
+        if (!currency) {
             throw Error(
                 `Token ${upperCaseTokenSymbol} is not internally mapped in ${this.api} API`
             );
         }
-        return resultMapping;
+
+        return this.currencyMapping[currency];
     }
 
     abstract queryExchangeRate(

--- a/src/api/ExchangeApi.ts
+++ b/src/api/ExchangeApi.ts
@@ -1,8 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-const avialableCurrencies = ['TRIF', 'RIF', 'RDOC', 'RBTC', 'TKN'] as const;
-
-export type FromCurrency = typeof avialableCurrencies[number];
+export type FromCurrency = 'TRIF' | 'RIF' | 'RDOC' | 'RBTC' | 'TKN';
 
 export type CurrencyMapping = Partial<Record<FromCurrency, string>>;
 
@@ -26,16 +24,16 @@ export default abstract class BaseExchangeApi {
 
         const upperCaseTokenSymbol = tokenSymbol.toUpperCase();
 
-        const currency = avialableCurrencies.find(
-            (c) => c === upperCaseTokenSymbol
-        );
+        const currency =
+            this.currencyMapping[upperCaseTokenSymbol as FromCurrency];
+
         if (!currency) {
             throw Error(
                 `Token ${upperCaseTokenSymbol} is not internally mapped in ${this.api} API`
             );
         }
 
-        return this.currencyMapping[currency];
+        return currency;
     }
 
     abstract queryExchangeRate(

--- a/src/api/RdocExchange.ts
+++ b/src/api/RdocExchange.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import BaseExchangeApi from './ExchangeApi';
+import BaseExchangeApi, { CurrencyMapping } from './ExchangeApi';
 
 type RateRecord = Record<string, string>;
 
@@ -9,7 +9,7 @@ const rates: Record<string, RateRecord> = {
     }
 };
 
-const CURRENCY_MAPPING: Record<string, string> = {
+const CURRENCY_MAPPING: CurrencyMapping = {
     RDOC: 'RDOC'
 };
 

--- a/src/api/TestExchange.ts
+++ b/src/api/TestExchange.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import BaseExchangeApi from './ExchangeApi';
+import BaseExchangeApi, { CurrencyMapping } from './ExchangeApi';
 
 type RateRecord = Record<string, string>;
 
@@ -12,7 +12,7 @@ const rates: Record<string, RateRecord> = {
     }
 };
 
-const CURRENCY_MAPPING: Record<string, string> = {
+const CURRENCY_MAPPING: CurrencyMapping = {
     TKN: 'TKN',
     RBTC: 'RBTC'
 };

--- a/test/RelayPricer.test.ts
+++ b/test/RelayPricer.test.ts
@@ -32,6 +32,13 @@ describe('RelayPricer', () => {
             assert.containsAllKeys(availableApi, ['api', 'tokens']);
         });
 
+        it('should return available api(lowercase)', () => {
+            const availableApi = pricer.findAvailableApi(
+                RIF_SYMBOL.toLowerCase()
+            );
+            assert.containsAllKeys(availableApi, ['api', 'tokens']);
+        });
+
         it('should return available api for RDOC', () => {
             const availableApi = pricer.findAvailableApi('RDOC');
             assert.containsAllKeys(availableApi, ['api', 'tokens']);


### PR DESCRIPTION
## What

- The relayPricer and API needs to handle case sensitive Currencies and Tokens. 
- Typing to guarantee the appropriate name.

## Why

- There are different type of casing for tokens and currencies and we need to be able to let the programmer know that the name that is using is valid.

## Refs

- (PP-570)[https://rsklabs.atlassian.net/browse/PP-570]
