### PR TITLE
feat(ethers): unifies deploy/relay prepareHttpRequest in RelayClient

### DIFF
--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -43,16 +43,16 @@ export default class AccountManager {
     return 'index' in request;
   }
 
-  async sign(relayRequest: EnvelopingRequest): Promise<string> {
-    const callForwarder = relayRequest.relayData.callForwarder.toString();
+  async sign(envelopingRequest: EnvelopingRequest): Promise<string> {
+    const callForwarder = envelopingRequest.relayData.callForwarder.toString();
     const fromAddress: string = getAddress(
-      relayRequest.request.from.toString()
+      envelopingRequest.request.from.toString()
     );
-    const isDeploy = this.isDeployRequest(relayRequest);
+    const isDeploy = this.isDeployRequest(envelopingRequest);
     const data = getEnvelopingRequestDataV4Field({
       chainId: this.chainId,
       verifier: callForwarder,
-      relayRequest,
+      envelopingRequest,
       requestTypes: isDeploy ? deployRequestType : relayRequestType,
     });
     const wallet = this._accounts.find(

--- a/src/common/relayRequest.types.ts
+++ b/src/common/relayRequest.types.ts
@@ -7,7 +7,10 @@ type DeployRequest = EnvelopingTypes.DeployRequestStruct;
 type RelayRequestBody = RelayRequest['request'];
 type DeployRequestBody = DeployRequest['request'];
 
-type EnvelopingRequest = Either<RelayRequest, DeployRequest>;
+type EnvelopingRequest = {
+  request: Either<RelayRequestBody, DeployRequestBody>;
+  relayData: EnvelopingRequestData;
+};
 
 type UserDefinedRelayRequestBody = Modify<
   RelayRequestBody,

--- a/src/common/relayTransaction.types.ts
+++ b/src/common/relayTransaction.types.ts
@@ -1,5 +1,9 @@
 import type { EnvelopingMetadata } from './relayHub.types';
-import type { DeployRequest, RelayRequest } from './relayRequest.types';
+import type {
+  DeployRequest,
+  EnvelopingRequest,
+  RelayRequest,
+} from './relayRequest.types';
 
 type RelayTransactionRequest = {
   relayRequest: RelayRequest;
@@ -11,7 +15,10 @@ type DeployTransactionRequest = {
   metadata: EnvelopingMetadata;
 };
 
-type EnvelopingTxRequest = RelayTransactionRequest | DeployTransactionRequest;
+type EnvelopingTxRequest = {
+  relayRequest: EnvelopingRequest;
+  metadata: EnvelopingMetadata;
+};
 
 export {
   RelayTransactionRequest,

--- a/src/typedRequestData.utils.ts
+++ b/src/typedRequestData.utils.ts
@@ -5,7 +5,7 @@ import {
   TypedDataUtils,
   TypedMessage,
 } from '@metamask/eth-sig-util';
-import type { EnvelopingTypes } from '@rsksmart/rif-relay-contracts/dist/typechain-types/contracts/RelayHub';
+import type { EnvelopingRequest } from './common/relayRequest.types';
 
 export type EIP712Domain = TypedMessage<EnvelopingMessageTypes>['domain'];
 
@@ -78,16 +78,14 @@ export const getDomainSeparatorHash = (
 type GetRequestDataFieldProps = {
   chainId: number;
   verifier: string;
-  relayRequest:
-    | EnvelopingTypes.RelayRequestStruct
-    | EnvelopingTypes.DeployRequestStruct;
+  envelopingRequest: EnvelopingRequest;
   requestTypes: MessageTypeProperty[];
 };
 
 export const getEnvelopingRequestDataV4Field = ({
   chainId,
-  verifier, // is this separated from the relay request by design?
-  relayRequest,
+  verifier,
+  envelopingRequest,
   requestTypes,
 }: GetRequestDataFieldProps): TypedMessage<EnvelopingMessageTypes> => ({
   types: {
@@ -95,10 +93,10 @@ export const getEnvelopingRequestDataV4Field = ({
     RelayRequest: requestTypes,
     RelayData: relayDataType,
   },
-  primaryType: 'RelayRequest', // what if it's deploy request?
+  primaryType: 'RelayRequest',
   domain: getDomainSeparator(verifier, chainId),
   message: {
-    ...relayRequest.request,
-    relayData: relayRequest.relayData,
+    ...envelopingRequest.request,
+    relayData: envelopingRequest.relayData,
   },
 });


### PR DESCRIPTION
## What

- adapts _prepareDeployHttpRequest to using ethers and new typing, removing the need for building request details
- removes request details building in _prepareRelayHttpRequest

## Refs

- [ticket PP-616](https://rsklabs.atlassian.net/browse/PP-616)
