### PR TITLE
Fix: update rif-relay-contracts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@rsksmart/rif-relay-contracts": "v2.0.0-beta.0",
+    "@rsksmart/rif-relay-contracts": "2.0.0-beta.0",
     "ethers": "^5.7.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## What

- Fix relay contracts peer dependency

## Why

- The format was wrong (starting with `v2.0.0-beta.0` instead of `2.0.0-beta.0`)
