### PR TITLE
PP-633/relay-sever-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": false,
   "description": "This project contains all the client code for the rif relay system.",
   "license": "MIT",

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -146,7 +146,8 @@ class RelayClient extends EnvelopingEventEmitter {
     }
 
     const gasPrice: PromiseOrValue<BigNumberish> =
-      envelopingRequest.relayData?.gasPrice || (await this.calculateGasPrice());
+      envelopingRequest.relayData?.gasPrice ||
+      (await this._calculateGasPrice());
 
     if (!gasPrice || BigNumber.from(gasPrice).isZero()) {
       throw new Error('Could not get gas price for request');
@@ -330,7 +331,7 @@ class RelayClient extends EnvelopingEventEmitter {
     return httpRequest;
   }
 
-  async calculateGasPrice(): Promise<BigNumber> {
+  private async _calculateGasPrice(): Promise<BigNumber> {
     const { minGasPrice, gasPriceFactorPercent } = this._envelopingConfig;
 
     const provider = getProvider();

--- a/src/api/common/HttpClient.ts
+++ b/src/api/common/HttpClient.ts
@@ -28,8 +28,11 @@ class HttpClient {
 
   async getChainInfo(relayUrl: string, verifier = ''): Promise<HubInfo> {
     const verifierSuffix = verifier && `${VERIFIER_SUFFIX}${verifier}`;
+
+    const url = new URL(PATHS.CHAIN_INFO + verifierSuffix, relayUrl);
+
     const hubInfo: HubInfo = await this._httpWrapper.sendPromise(
-      relayUrl + PATHS.CHAIN_INFO + verifierSuffix
+      url.toString()
     );
     log.info(`hubInfo: ${JSON.stringify(hubInfo)}`);
     requestInterceptors.logRequest.onErrorResponse({
@@ -73,9 +76,11 @@ class HttpClient {
     relayUrl: string,
     envelopingTx: EnvelopingTxRequest
   ): Promise<string> {
+    const url = new URL(PATHS.POST_RELAY_REQUEST, relayUrl);
+
     const { signedTx } =
       await this._httpWrapper.sendPromise<SignedTransactionDetails>(
-        relayUrl + PATHS.POST_RELAY_REQUEST,
+        url.toString(),
         this._stringifyEnvelopingTx(envelopingTx)
       );
     log.info('relayTransaction response:', signedTx);
@@ -93,8 +98,10 @@ class HttpClient {
     relayUrl: string,
     envelopingTx: EnvelopingTxRequest
   ): Promise<RelayEstimation> {
+    const url = new URL(PATHS.POST_ESTIMATE, relayUrl);
+
     const response = await this._httpWrapper.sendPromise<RelayEstimation>(
-      relayUrl + PATHS.POST_ESTIMATE,
+      url.toString(),
       this._stringifyEnvelopingTx(envelopingTx)
     );
     log.info('esimation relayTransaction response:', response);

--- a/src/gasEstimator/gasEstimator.ts
+++ b/src/gasEstimator/gasEstimator.ts
@@ -51,11 +51,12 @@ const estimateRelayMaxPossibleGas = async (
   });
 
   if (signature > '0x0') {
-    return await standardMaxPossibleGasEstimation(
+    const maxPossibleGas = await standardMaxPossibleGasEstimation(
       envelopingRequest,
-      relayWorkerAddress,
-      tokenEstimation
+      relayWorkerAddress
     );
+
+    return maxPossibleGas.add(tokenEstimation);
   }
 
   return await linearFitMaxPossibleGasEstimation(relayRequest, tokenEstimation);

--- a/src/gasEstimator/utils.ts
+++ b/src/gasEstimator/utils.ts
@@ -17,7 +17,6 @@ import { getProvider } from '../common/clientConfigurator';
 const standardMaxPossibleGasEstimation = async (
   { relayRequest, metadata: { signature } }: EnvelopingTxRequest,
   relayWorkerAddress: string,
-  tokenEstimation: BigNumberish,
   estimatedGasCorrectionFactor?: BigNumberish
 ): Promise<BigNumber> => {
   const {
@@ -50,7 +49,7 @@ const standardMaxPossibleGasEstimation = async (
     estimatedGasCorrectionFactor
   );
 
-  return correctedEstimation.add(tokenEstimation);
+  return correctedEstimation;
 };
 
 const linearFitMaxPossibleGasEstimation = async (

--- a/test/RelayClient.test.ts
+++ b/test/RelayClient.test.ts
@@ -126,6 +126,7 @@ describe('RelayClient', function () {
         hubInfo: HubInfo,
         envelopingRequest: EnvelopingRequest
       ) => Promise<EnvelopingTxRequest>;
+      _calculateGasPrice(): Promise<BigNumber>;
       _getEnvelopingRequestDetails: (
         envelopingRequest: UserDefinedEnvelopingRequest
       ) => Promise<EnvelopingRequest>;
@@ -466,7 +467,7 @@ describe('RelayClient', function () {
         const expectedGasPrice = BigNumber.from(
           (Math.random() * 100).toFixed(0)
         );
-        relayClient.calculateGasPrice = sandbox
+        relayClient._calculateGasPrice = sandbox
           .stub()
           .resolves(expectedGasPrice);
 
@@ -484,7 +485,7 @@ describe('RelayClient', function () {
       });
 
       it('should throw error if gasPrice not in request data or calculated', async function () {
-        relayClient.calculateGasPrice = sandbox.stub().resolves(undefined);
+        relayClient._calculateGasPrice = sandbox.stub().resolves(undefined);
 
         const call = relayClient._getEnvelopingRequestDetails({
           ...FAKE_DEPLOY_REQUEST,
@@ -804,7 +805,7 @@ describe('RelayClient', function () {
       });
     });
 
-    describe('calculateGasPrice', function () {
+    describe('_calculateGasPrice', function () {
       it('should return minGasPrice when minGasPrice is higher than gas price from provider', async function () {
         const expectedGasPrice = 30000;
         relayClient._envelopingConfig.minGasPrice = expectedGasPrice;
@@ -814,7 +815,7 @@ describe('RelayClient', function () {
             console.log('getGasPrice called');
           })
           .resolves(BigNumber.from(2000));
-        const actualGasPrice = await relayClient.calculateGasPrice();
+        const actualGasPrice = await relayClient._calculateGasPrice();
 
         expect(actualGasPrice.toNumber()).to.be.equal(expectedGasPrice);
       });
@@ -825,7 +826,7 @@ describe('RelayClient', function () {
         const expectedGasEstimate = estimateGas.mul(
           FAKE_ENVELOPING_CONFIG.gasPriceFactorPercent + 1
         );
-        const actualGasPrice = await relayClient.calculateGasPrice();
+        const actualGasPrice = await relayClient._calculateGasPrice();
 
         expect(actualGasPrice.toString()).to.be.equal(
           expectedGasEstimate.toString()

--- a/test/gasEstimator/gasEstimator.test.ts
+++ b/test/gasEstimator/gasEstimator.test.ts
@@ -75,9 +75,11 @@ describe('GasEstimator', function () {
         relayWorker
       );
 
+      const expectedEstimation = fakeRelayEstimation.add(fakeTokenGas);
+
       expect(
-        estimation.eq(fakeRelayEstimation),
-        `${estimation.toString()} should equal ${fakeRelayEstimation.toString()}`
+        estimation.eq(expectedEstimation),
+        `${estimation.toString()} should equal ${expectedEstimation.toString()}`
       ).to.be.true;
     });
 
@@ -91,9 +93,11 @@ describe('GasEstimator', function () {
         relayWorker
       );
 
+      const expectedEstimation = fakeDeployEstimation.add(fakeTokenGas);
+
       expect(
-        estimation.eq(fakeDeployEstimation),
-        `${estimation.toString()} should equal ${fakeDeployEstimation.toString()}`
+        estimation.eq(expectedEstimation),
+        `${estimation.toString()} should equal ${expectedEstimation.toString()}`
       ).to.be.true;
     });
 
@@ -140,7 +144,6 @@ describe('GasEstimator', function () {
   });
 
   describe('standardMaxPossibleGasEstimation', function () {
-    let fakeTokenGas: BigNumber;
     let fakeDeployGas: BigNumber;
     let fakeRelayGas: BigNumber;
     let relayWorker: string;
@@ -148,7 +151,6 @@ describe('GasEstimator', function () {
     let relayHubStub: SinonStubbedInstance<RelayHub>;
 
     beforeEach(function () {
-      fakeTokenGas = randomBigNumber(10000);
       fakeDeployGas = randomBigNumber(10000);
       fakeRelayGas = randomBigNumber(10000);
       relayWorker = Wallet.createRandom().address;
@@ -174,15 +176,12 @@ describe('GasEstimator', function () {
 
       const estimation = await standardMaxPossibleGasEstimation(
         FAKE_RELAY_TRANSACTION_REQUEST,
-        relayWorker,
-        fakeTokenGas
+        relayWorker
       );
 
-      const relayEstimation = fakeTokenGas.add(fakeRelayGas);
-
       expect(
-        estimation.eq(relayEstimation),
-        `${estimation.toString()} should equal ${relayEstimation.toString()}`
+        estimation.eq(fakeRelayGas),
+        `${estimation.toString()} should equal ${fakeRelayGas.toString()}`
       ).to.be.true;
     });
 
@@ -191,14 +190,12 @@ describe('GasEstimator', function () {
 
       const estimation = await standardMaxPossibleGasEstimation(
         FAKE_DEPLOY_TRANSACTION_REQUEST,
-        relayWorker,
-        fakeTokenGas
+        relayWorker
       );
-      const relayEstimation = fakeTokenGas.add(fakeDeployGas);
 
       expect(
-        estimation.eq(relayEstimation),
-        `${estimation.toString()} should equal ${relayEstimation.toString()}`
+        estimation.eq(fakeDeployGas),
+        `${estimation.toString()} should equal ${fakeDeployGas.toString()}`
       ).to.be.true;
     });
   });


### PR DESCRIPTION
## What

- Token inclusion while doing gas estimation
- Access for calculateGasPrice

## Why

- Bug found during integration test, since value was added twice
- calculateGasPrice its just needed to use for relaying transactins

## Refs

- [PP-633](https://rsklabs.atlassian.net/browse/PP-633)
