### PR TITLE
PP718: Relay transaction with a not stored primary key

### DIFF
--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -56,7 +56,6 @@ export default class AccountManager {
     envelopingRequest: EnvelopingRequest,
     signerWalletOnTheFly?: Wallet
   ): Promise<string> {
-    console.log('****sign59: in');
     const callForwarder = envelopingRequest.relayData.callForwarder.toString();
     const provider = getProvider();
     const { chainId } = await provider.getNetwork();
@@ -67,8 +66,6 @@ export default class AccountManager {
       this._accounts.find(
         (account) => getAddress(account.address) === fromAddress
       );
-
-    console.log('****sign79: signerWallet: ', signerWallet);
 
     const data = getEnvelopingRequestDataV4Field({
       chainId,
@@ -105,19 +102,10 @@ export default class AccountManager {
     from: string,
     wallet?: Wallet
   ): Promise<{ signature: string; recoveredAddr: string }> {
-    console.log('********_getSignatureFromTypedData in');
     const signature: string = wallet
       ? await this._signWithWallet(wallet, data)
       : await this._signWithProvider(from, data);
     const recoveredAddr = this._recoverSignature(data, signature);
-    console.log(
-      '********_getSignatureFromTypedData wallet.address: ',
-      wallet?.address
-    );
-    console.log(
-      '********_getSignatureFromTypedData recoveredAddr: ',
-      recoveredAddr
-    );
 
     return { signature, recoveredAddr };
   }
@@ -167,7 +155,6 @@ export default class AccountManager {
     wallet: Wallet,
     data: TypedMessage<EnvelopingMessageTypes>
   ): Promise<string> {
-    console.log('***********_signWithWallet in');
     const { domain, types, value } = data;
 
     return await wallet._signTypedData(domain, types, value);

--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -33,7 +33,7 @@ export default class AccountManager {
 
   addAccount(account: Wallet): void {
     const provider = getProvider();
-    const wallet = new Wallet(account.privateKey, provider); //***************?????????? */
+    const wallet = new Wallet(account.privateKey, provider);
     if (wallet.address !== account.address) {
       throw new Error('invalid keypair');
     }

--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -48,7 +48,7 @@ export default class AccountManager {
     if (indexToRemove !== -1) {
       this._accounts.splice(indexToRemove, 1);
     } else {
-      throw new Error('Account not founded');
+      throw new Error('Account not found');
     }
   }
 

--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -110,8 +110,14 @@ export default class AccountManager {
       ? await this._signWithWallet(wallet, data)
       : await this._signWithProvider(from, data);
     const recoveredAddr = this._recoverSignature(data, signature);
-    console.log('********_getSignatureFromTypedData wallet.address: ', wallet?.address);
-    console.log('********_getSignatureFromTypedData recoveredAddr: ', recoveredAddr);
+    console.log(
+      '********_getSignatureFromTypedData wallet.address: ',
+      wallet?.address
+    );
+    console.log(
+      '********_getSignatureFromTypedData recoveredAddr: ',
+      recoveredAddr
+    );
 
     return { signature, recoveredAddr };
   }

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -373,11 +373,9 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     options?: RelayTxOptions
   ): Promise<Transaction> {
-    const signerWallet = options?.signerWallet;
-
     const { envelopingTx, activeRelay } = await this._getHubEnvelopingTx(
       envelopingRequest,
-      signerWallet
+      options?.signerWallet
     );
 
     log.debug('Relay Client - Relaying transaction');
@@ -405,14 +403,15 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     options?: RelayTxOptions
   ): Promise<RelayEstimation> {
-    const signerWallet = options?.signerWallet;
-
     const {
       envelopingTx,
       activeRelay: {
         managerData: { url },
       },
-    } = await this._getHubEnvelopingTx(envelopingRequest, signerWallet);
+    } = await this._getHubEnvelopingTx(
+      envelopingRequest,
+      options?.signerWallet
+    );
 
     log.debug('Relay Client - Estimating transaction');
     log.debug(

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -89,11 +89,9 @@ class RelayClient extends EnvelopingEventEmitter {
   private _getEnvelopingRequestDetails = async (
     envelopingRequest: UserDefinedEnvelopingRequest
   ): Promise<EnvelopingRequest> => {
-    console.log('RelayClient _getEnvelopingRequestDetails92');
     const isDeployment: boolean = isDeployRequest(
       envelopingRequest as EnvelopingRequest
     );
-    console.log('RelayClient _getEnvelopingRequestDetails96');
     const { relayData, request } = envelopingRequest;
 
     const { from, tokenContract } = request;
@@ -101,14 +99,12 @@ class RelayClient extends EnvelopingEventEmitter {
     if (!from) {
       throw new Error(MISSING_REQUEST_FIELD('from'));
     }
-    console.log('RelayClient _getEnvelopingRequestDetails104');
 
     if (!tokenContract) {
       throw new Error(MISSING_REQUEST_FIELD('tokenContract'));
     }
 
     if (!isDeployment) {
-      console.log('RelayClient _getEnvelopingRequestDetails111');
       if (!relayData?.callForwarder) {
         throw new Error(MISSING_CALL_FORWARDER);
       }
@@ -122,7 +118,6 @@ class RelayClient extends EnvelopingEventEmitter {
       }
     }
 
-    console.log('RelayClient _getEnvelopingRequestDetails125');
     const callForwarder =
       relayData?.callForwarder ??
       this._envelopingConfig.smartWalletFactoryAddress;
@@ -130,21 +125,18 @@ class RelayClient extends EnvelopingEventEmitter {
     const to = request.to ?? constants.AddressZero;
     const value = envelopingRequest.request.value ?? constants.Zero;
     const tokenAmount = envelopingRequest.request.tokenAmount ?? constants.Zero;
-    console.log('RelayClient _getEnvelopingRequestDetails133');
 
     const { index } = request as UserDefinedDeployRequestBody;
 
     if (isDeployment && isNullOrUndefined(index)) {
       throw new Error('Field `index` is not defined in deploy body.');
     }
-    console.log('RelayClient _getEnvelopingRequestDetails140');
 
     const callVerifier: PromiseOrValue<string> =
       envelopingRequest.relayData?.callVerifier ||
       this._envelopingConfig[
         isDeployment ? 'deployVerifierAddress' : 'relayVerifierAddress'
       ];
-    console.log('RelayClient _getEnvelopingRequestDetails147');
 
     if (!callVerifier) {
       throw new Error('No call verifier present. Check your configuration.');
@@ -157,7 +149,6 @@ class RelayClient extends EnvelopingEventEmitter {
         'Check that your configuration contains at least one preferred relay with url.'
       );
     }
-    console.log('RelayClient _getEnvelopingRequestDetails160');
 
     const gasPrice: PromiseOrValue<BigNumberish> =
       envelopingRequest.relayData?.gasPrice ||
@@ -167,17 +158,8 @@ class RelayClient extends EnvelopingEventEmitter {
       throw new Error('Could not get gas price for request');
     }
 
-    console.log('RelayClient _getEnvelopingRequestDetails170');
     const provider = getProvider();
 
-    console.log(
-      'RelayClient _getEnvelopingRequestDetails173 isDeployment, ',
-      isDeployment
-    );
-    console.log(
-      'RelayClient _getEnvelopingRequestDetails173 callForwarder, ',
-      callForwarder
-    );
     const nonce =
       (envelopingRequest.request.nonce ||
         (isDeployment
@@ -191,7 +173,6 @@ class RelayClient extends EnvelopingEventEmitter {
             ).nonce())) ??
       constants.Zero;
 
-    console.log('RelayClient _getEnvelopingRequestDetails187');
     const relayHub =
       envelopingRequest.request.relayHub?.toString() ||
       this._envelopingConfig.relayHubAddress;
@@ -199,7 +180,6 @@ class RelayClient extends EnvelopingEventEmitter {
     if (!relayHub) {
       throw new Error('No relay hub address has been given or configured');
     }
-    console.log('RelayClient _getEnvelopingRequestDetails195');
 
     const gasLimit = await ((
       envelopingRequest.request as UserDefinedRelayRequestBody
@@ -216,12 +196,10 @@ class RelayClient extends EnvelopingEventEmitter {
         'Gas limit value (`gas`) is required in a relay request.'
       );
     }
-    console.log('RelayClient _getEnvelopingRequestDetails212');
 
     const recoverer =
       (envelopingRequest.request as DeployRequestBody).recoverer ??
       constants.AddressZero;
-    console.log('RelayClient _getEnvelopingRequestDetails217');
 
     const updateRelayData: EnvelopingRequestData = {
       callForwarder,
@@ -229,7 +207,6 @@ class RelayClient extends EnvelopingEventEmitter {
       feesReceiver: constants.AddressZero, // returns zero address and is to be completed when attempting to relay the transaction
       gasPrice,
     };
-    console.log('RelayClient _getEnvelopingRequestDetails225');
 
     const secondsNow = Math.round(Date.now() / 1000);
     const validUntilTime =
@@ -237,7 +214,6 @@ class RelayClient extends EnvelopingEventEmitter {
       secondsNow + this._envelopingConfig.requestValidSeconds;
 
     const tokenGas = request.tokenGas ?? constants.Zero;
-    console.log('RelayClient _getEnvelopingRequestDetails223');
 
     const commonRequestBody: CommonEnvelopingRequestBody = {
       data,
@@ -251,7 +227,6 @@ class RelayClient extends EnvelopingEventEmitter {
       value,
       validUntilTime,
     };
-    console.log('RelayClient _getEnvelopingRequestDetails247');
 
     const completeRequest: EnvelopingRequest = isDeployment
       ? {
@@ -273,7 +248,6 @@ class RelayClient extends EnvelopingEventEmitter {
           },
           relayData: updateRelayData,
         };
-    console.log('RelayClient _getEnvelopingRequestDetails269');
 
     return completeRequest;
   };
@@ -283,7 +257,6 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: EnvelopingRequest,
     signerWallet?: Wallet
   ): Promise<EnvelopingTxRequest> {
-    console.log('RelayClient _prepareHttpRequest');
     const {
       request: { relayHub, tokenGas },
     } = envelopingRequest;
@@ -400,19 +373,12 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     options?: RelayTxOptions
   ): Promise<Transaction> {
-    console.log(
-      'RelayClient relayTransaction() envelopingRequest: ',
-      envelopingRequest
-    );
-    console.log('RelayClient relayTransaction() options: ', options);
     const signerWallet = options?.signerWallet;
-    console.log('RelayClient relayTransaction() signerWallet: ', signerWallet);
 
     const { envelopingTx, activeRelay } = await this._getHubEnvelopingTx(
       envelopingRequest,
       signerWallet
     );
-    console.log('RelayClient relayTransaction() after _getHubEnvelopingTx');
 
     log.debug('Relay Client - Relaying transaction');
     log.debug(
@@ -463,7 +429,6 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     signerWallet?: Wallet
   ): Promise<HubEnvelopingTx> {
-    console.log('RelayClient _getHubEnvelopingTx');
     const envelopingRequestDetails = await this._getEnvelopingRequestDetails(
       envelopingRequest
     );

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -629,4 +629,4 @@ class RelayClient extends EnvelopingEventEmitter {
 
 export default RelayClient;
 
-export { RelayTxOptions as relayTxOptions };
+export { RelayTxOptions };

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -13,7 +13,7 @@ import {
   CallOverrides,
   constants,
   Transaction,
-  Wallet
+  Wallet,
 } from 'ethers';
 import {
   isAddress,
@@ -71,7 +71,7 @@ const isNullOrUndefined = (value: unknown) =>
   value === null || value === undefined;
 
 type RelayTxOptions = {
-  signerWallet: Wallet
+  signerWallet: Wallet;
 };
 
 class RelayClient extends EnvelopingEventEmitter {
@@ -144,7 +144,7 @@ class RelayClient extends EnvelopingEventEmitter {
       this._envelopingConfig[
         isDeployment ? 'deployVerifierAddress' : 'relayVerifierAddress'
       ];
-      console.log('RelayClient _getEnvelopingRequestDetails147');
+    console.log('RelayClient _getEnvelopingRequestDetails147');
 
     if (!callVerifier) {
       throw new Error('No call verifier present. Check your configuration.');
@@ -170,8 +170,14 @@ class RelayClient extends EnvelopingEventEmitter {
     console.log('RelayClient _getEnvelopingRequestDetails170');
     const provider = getProvider();
 
-    console.log('RelayClient _getEnvelopingRequestDetails173 isDeployment, ', isDeployment);
-    console.log('RelayClient _getEnvelopingRequestDetails173 callForwarder, ', callForwarder);
+    console.log(
+      'RelayClient _getEnvelopingRequestDetails173 isDeployment, ',
+      isDeployment
+    );
+    console.log(
+      'RelayClient _getEnvelopingRequestDetails173 callForwarder, ',
+      callForwarder
+    );
     const nonce =
       (envelopingRequest.request.nonce ||
         (isDeployment
@@ -179,13 +185,13 @@ class RelayClient extends EnvelopingEventEmitter {
               callForwarder.toString(),
               provider
             ).nonce(from)
-            : await IForwarder__factory.connect(
+          : await IForwarder__factory.connect(
               callForwarder.toString(),
               provider
             ).nonce())) ??
       constants.Zero;
 
-      console.log('RelayClient _getEnvelopingRequestDetails187');
+    console.log('RelayClient _getEnvelopingRequestDetails187');
     const relayHub =
       envelopingRequest.request.relayHub?.toString() ||
       this._envelopingConfig.relayHubAddress;
@@ -215,7 +221,7 @@ class RelayClient extends EnvelopingEventEmitter {
     const recoverer =
       (envelopingRequest.request as DeployRequestBody).recoverer ??
       constants.AddressZero;
-      console.log('RelayClient _getEnvelopingRequestDetails217');
+    console.log('RelayClient _getEnvelopingRequestDetails217');
 
     const updateRelayData: EnvelopingRequestData = {
       callForwarder,
@@ -267,7 +273,7 @@ class RelayClient extends EnvelopingEventEmitter {
           },
           relayData: updateRelayData,
         };
-        console.log('RelayClient _getEnvelopingRequestDetails269');
+    console.log('RelayClient _getEnvelopingRequestDetails269');
 
     return completeRequest;
   };
@@ -394,9 +400,12 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     options?: RelayTxOptions
   ): Promise<Transaction> {
-    console.log('RelayClient relayTransaction() envelopingRequest: ', envelopingRequest);
+    console.log(
+      'RelayClient relayTransaction() envelopingRequest: ',
+      envelopingRequest
+    );
     console.log('RelayClient relayTransaction() options: ', options);
-    const signerWallet =  options?.signerWallet;
+    const signerWallet = options?.signerWallet;
     console.log('RelayClient relayTransaction() signerWallet: ', signerWallet);
 
     const { envelopingTx, activeRelay } = await this._getHubEnvelopingTx(
@@ -430,7 +439,7 @@ class RelayClient extends EnvelopingEventEmitter {
     envelopingRequest: UserDefinedEnvelopingRequest,
     options?: RelayTxOptions
   ): Promise<RelayEstimation> {
-    const signerWallet =  options?.signerWallet;
+    const signerWallet = options?.signerWallet;
 
     const {
       envelopingTx,
@@ -655,4 +664,4 @@ class RelayClient extends EnvelopingEventEmitter {
 
 export default RelayClient;
 
-export {RelayTxOptions as relayTxOptions}; 
+export { RelayTxOptions as relayTxOptions };

--- a/src/api/pricer/CoinBase.ts
+++ b/src/api/pricer/CoinBase.ts
@@ -1,9 +1,9 @@
 import type { ResponseError } from 'superagent';
 import { BigNumber as BigNumberJs } from 'bignumber.js';
 import BaseExchangeApi, { CurrencyMapping } from './ExchangeApi';
-import HttpWrapper from '../common/HttpWrapper';
+// import HttpWrapper from '../common/HttpWrapper';
 
-const URL = 'https://api.coinbase.com/v2/exchange-rates';
+// const URL = 'https://api.coinbase.com/v2/exchange-rates';
 
 export type CoinBaseResponse = {
   data: {
@@ -19,11 +19,11 @@ const CURRENCY_MAPPING: CurrencyMapping = {
 };
 
 export default class CoinBase extends BaseExchangeApi {
-  private readonly _httpWrapper: HttpWrapper;
+  // private readonly _httpWrapper: HttpWrapper;
 
-  constructor(httpWrapper: HttpWrapper = new HttpWrapper()) {
+  constructor(/*httpWrapper: HttpWrapper = new HttpWrapper()*/) {
     super('CoinBase', CURRENCY_MAPPING, ['RIF', 'RBTC', 'tRif']);
-    this._httpWrapper = httpWrapper;
+    // this._httpWrapper = httpWrapper;
   }
 
   async queryExchangeRate(
@@ -34,9 +34,17 @@ export default class CoinBase extends BaseExchangeApi {
     let response: CoinBaseResponse;
 
     try {
-      response = await this._httpWrapper.sendPromise<CoinBaseResponse>(
+      /* response =await this._httpWrapper.sendPromise<CoinBaseResponse>(
         `${URL}?currency=${sourceCurrency}`
-      );
+      );*/
+      response = await Promise.resolve({
+        data: {
+          currency: 'RBTC',
+          rates: {
+            'USD': '22096.37'
+          },
+        }
+      });
     } catch (error: unknown) {
       const { response } = error as ResponseError;
 
@@ -51,6 +59,7 @@ export default class CoinBase extends BaseExchangeApi {
       data: { rates },
     }: CoinBaseResponse = response;
     const conversionRate = rates[upperCaseTargetCurrency];
+    console.log('conversionRate: ', conversionRate);
 
     if (!conversionRate) {
       throw Error(
@@ -58,6 +67,9 @@ export default class CoinBase extends BaseExchangeApi {
       );
     }
 
-    return BigNumberJs(conversionRate);
+    const returnValue = BigNumberJs(conversionRate);
+    console.log('ConversionRate to BigNumberJS', returnValue.toString());
+    
+    return returnValue;
   }
 }

--- a/src/api/pricer/CoinBase.ts
+++ b/src/api/pricer/CoinBase.ts
@@ -1,9 +1,9 @@
 import type { ResponseError } from 'superagent';
 import { BigNumber as BigNumberJs } from 'bignumber.js';
 import BaseExchangeApi, { CurrencyMapping } from './ExchangeApi';
-// import HttpWrapper from '../common/HttpWrapper';
+import HttpWrapper from '../common/HttpWrapper';
 
-// const URL = 'https://api.coinbase.com/v2/exchange-rates';
+const URL = 'https://api.coinbase.com/v2/exchange-rates';
 
 export type CoinBaseResponse = {
   data: {
@@ -19,11 +19,11 @@ const CURRENCY_MAPPING: CurrencyMapping = {
 };
 
 export default class CoinBase extends BaseExchangeApi {
-  // private readonly _httpWrapper: HttpWrapper;
+  private readonly _httpWrapper: HttpWrapper;
 
-  constructor(/*httpWrapper: HttpWrapper = new HttpWrapper()*/) {
+  constructor(httpWrapper: HttpWrapper = new HttpWrapper()) {
     super('CoinBase', CURRENCY_MAPPING, ['RIF', 'RBTC', 'tRif']);
-    // this._httpWrapper = httpWrapper;
+    this._httpWrapper = httpWrapper;
   }
 
   async queryExchangeRate(
@@ -34,17 +34,9 @@ export default class CoinBase extends BaseExchangeApi {
     let response: CoinBaseResponse;
 
     try {
-      /* response =await this._httpWrapper.sendPromise<CoinBaseResponse>(
+      response = await this._httpWrapper.sendPromise<CoinBaseResponse>(
         `${URL}?currency=${sourceCurrency}`
-      );*/
-      response = await Promise.resolve({
-        data: {
-          currency: 'RBTC',
-          rates: {
-            'USD': '22096.37'
-          },
-        }
-      });
+      );
     } catch (error: unknown) {
       const { response } = error as ResponseError;
 
@@ -59,7 +51,6 @@ export default class CoinBase extends BaseExchangeApi {
       data: { rates },
     }: CoinBaseResponse = response;
     const conversionRate = rates[upperCaseTargetCurrency];
-    console.log('conversionRate: ', conversionRate);
 
     if (!conversionRate) {
       throw Error(
@@ -67,9 +58,6 @@ export default class CoinBase extends BaseExchangeApi {
       );
     }
 
-    const returnValue = BigNumberJs(conversionRate);
-    console.log('ConversionRate to BigNumberJS', returnValue.toString());
-    
-    return returnValue;
+    return BigNumberJs(conversionRate);
   }
 }

--- a/test/AccountManager.test.ts
+++ b/test/AccountManager.test.ts
@@ -99,38 +99,37 @@ describe('AccountManager', function () {
     });
 
     describe('removeAccount()', function () {
-      let fakeAccounts: Array<Wallet>;
+      let randomAccounts: Array<Wallet>;
+      let initialLength: number;
 
       beforeEach(function () {
-        fakeAccounts = new Array<Wallet>(3).fill(Wallet.createRandom());
+        initialLength = 3;
+
+        randomAccounts = new Array<Wallet>(initialLength).fill(
+          Wallet.createRandom()
+        );
 
         (accountManager as unknown as { _accounts: Wallet[] })._accounts =
-          fakeAccounts;
+          randomAccounts;
       });
 
       it('Should remove only account sent as parameter', function () {
-        accountManager.removeAccount(fakeAccounts[1]?.address as string);
+        const expectedAccounts = [
+          randomAccounts[0]?.address,
+          randomAccounts[2]?.address,
+        ];
 
-        expect(
-          accountManager.getAccounts().length === fakeAccounts.length - 1,
-          'Incorrect length'
-        );
-        expect(
-          accountManager.getAccounts()[0] === fakeAccounts[0]?.address,
-          'First element missing'
-        );
-        expect(
-          accountManager.getAccounts()[1] === fakeAccounts[2]?.address,
-          'Second element missing'
-        );
+        accountManager.removeAccount(randomAccounts[1]?.address as string);
+
+        expect(accountManager.getAccounts()).to.be.deep.equal(expectedAccounts);
       });
 
       it('Should throw an error if the account sent as parameter does not exists', function () {
-        const inexistentWallet = Wallet.createRandom();
+        const nonexistentWallet = Wallet.createRandom();
 
         expect(() =>
-          accountManager.removeAccount(inexistentWallet.address)
-        ).to.throw('Account not founded');
+          accountManager.removeAccount(nonexistentWallet.address)
+        ).to.throw('Account not found');
       });
     });
 

--- a/test/AccountManager.test.ts
+++ b/test/AccountManager.test.ts
@@ -45,6 +45,11 @@ const relayRequest = {
   },
 };
 
+const ACCOUNTS_INITIAL_LENGTH = 3;
+const randomAccounts = Array(ACCOUNTS_INITIAL_LENGTH)
+  .fill(0)
+  .map(() => Wallet.createRandom());
+
 describe('AccountManager', function () {
   describe('methods', function () {
     let accountManager: AccountManager;
@@ -99,16 +104,7 @@ describe('AccountManager', function () {
     });
 
     describe('removeAccount()', function () {
-      let randomAccounts: Array<Wallet>;
-      let initialLength: number;
-
       beforeEach(function () {
-        initialLength = 3;
-
-        randomAccounts = new Array<Wallet>(initialLength).fill(
-          Wallet.createRandom()
-        );
-
         (accountManager as unknown as { _accounts: Wallet[] })._accounts =
           randomAccounts;
       });


### PR DESCRIPTION
## What

- Add functionality to receive a primary key and use it to sign and relay a transaction instead of an already stored account in the Account Manager.
- Add method to remove an account from the Account Manager.

## Why

- Partner requirement. 

## Refs

- [PP-718](https://rsklabs.atlassian.net/browse/PP-718)
