### PR TITLE
PP-635/relay-client-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepare": "scripts/prepare",
     "prepublishOnly": "scripts/prepublishOnly",
     "tdd": "npm run test -- --watch --watch-files src,test",
-    "test": "ALLOW_CONFIG_MUTATIONS=true npx mocha -r ts-node/register --extensions ts 'test/**/*.{test,spec}.ts'"
+    "test": "npx mocha -r ts-node/register --extensions ts 'test/**/*.{test,spec}.ts'"
   },
   "lint-staged": {
     "*.ts": "eslint --cache --fix",

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -56,7 +56,11 @@ import {
   NOT_RELAYED_TRANSACTION,
 } from './constants/errorMessages';
 import EnvelopingEventEmitter, {
-  envelopingEvents,
+  EVENT_INIT,
+  EVENT_RELAYER_RESPONSE,
+  EVENT_SEND_TO_RELAYER,
+  EVENT_SIGN_REQUEST,
+  EVENT_VALIDATE_REQUEST,
 } from './events/EnvelopingEventEmitter';
 import { estimateRelayMaxPossibleGas } from './gasEstimator';
 import {
@@ -327,7 +331,7 @@ class RelayClient extends EnvelopingEventEmitter {
       metadata,
     };
 
-    this.emit(envelopingEvents['sign-request']);
+    this.emit(EVENT_SIGN_REQUEST);
     log.info(
       `Created HTTP ${
         isDeployment ? 'deploy' : 'relay'
@@ -378,7 +382,7 @@ class RelayClient extends EnvelopingEventEmitter {
       options?.signerWallet
     );
 
-    this.emit('init');
+    this.emit(EVENT_INIT);
     log.debug('Relay Client - Relaying transaction');
     log.debug(
       `Relay Client - Relay Hub:${envelopingTx.metadata.relayHubAddress.toString()}`
@@ -457,7 +461,7 @@ class RelayClient extends EnvelopingEventEmitter {
         managerData: { url },
         hubInfo,
       } = relayInfo;
-      this.emit('send-to-relayer');
+      this.emit(EVENT_SEND_TO_RELAYER);
       log.info(
         `attempting relay: ${JSON.stringify(
           relayInfo
@@ -473,13 +477,13 @@ class RelayClient extends EnvelopingEventEmitter {
         transaction,
         hubInfo.relayWorkerAddress
       );
-      this.emit('relayer-response', true);
+      this.emit(EVENT_RELAYER_RESPONSE, true);
       await this._broadcastTx(signedTx);
 
       return transaction;
     } catch (e) {
       log.error('failed attempting to relay the transaction ', e);
-      this.emit('relayer-response', false);
+      this.emit(EVENT_RELAYER_RESPONSE, false);
 
       return undefined;
     }
@@ -515,7 +519,7 @@ class RelayClient extends EnvelopingEventEmitter {
     { relayWorkerAddress }: HubInfo,
     envelopingTx: EnvelopingTxRequest
   ): Promise<void> {
-    this.emit('validate-request');
+    this.emit(EVENT_VALIDATE_REQUEST);
     const {
       relayData: { gasPrice },
     } = envelopingTx.relayRequest;

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -79,11 +79,11 @@ class RelayClient extends EnvelopingEventEmitter {
 
   private readonly _httpClient: HttpClient;
 
-  constructor() {
+  constructor(httpClient: HttpClient = new HttpClient()) {
     super();
 
     this._envelopingConfig = getEnvelopingConfig();
-    this._httpClient = new HttpClient();
+    this._httpClient = httpClient;
   }
 
   private _getEnvelopingRequestDetails = async (
@@ -472,12 +472,13 @@ class RelayClient extends EnvelopingEventEmitter {
         transaction,
         hubInfo.relayWorkerAddress
       );
-      this.emit('relayer-response');
+      this.emit('relayer-response', true);
       await this._broadcastTx(signedTx);
 
       return transaction;
     } catch (e) {
       log.error('failed attempting to relay the transaction ', e);
+      this.emit('relayer-response', false);
 
       return undefined;
     }

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -378,6 +378,7 @@ class RelayClient extends EnvelopingEventEmitter {
       options?.signerWallet
     );
 
+    this.emit('init');
     log.debug('Relay Client - Relaying transaction');
     log.debug(
       `Relay Client - Relay Hub:${envelopingTx.metadata.relayHubAddress.toString()}`

--- a/src/events/EnvelopingEventEmitter.ts
+++ b/src/events/EnvelopingEventEmitter.ts
@@ -2,35 +2,32 @@ import EventEmitter from 'events';
 
 const events = {
   init: 'init',
-  enveloping: 'enveloping',
   'refresh-relays': 'refresh-relays', // TODO validate if its needed, since we do not refresh relays anymore
   'refreshed-relays': 'refreshed-relays', // TODO validate if its needed, since we do not refresh relays anymore
   'next-relay': 'next-relay',
   'sign-request': 'sign-request',
   'validate-request': 'validate-request',
   'send-to-relayer': 'send-to-relayer',
-  'relayer-response': 'relayer-response', // FIXME needs to have a boolean flag
+  'relayer-response': 'relayer-response',
 } as const;
 
 type Event = keyof typeof events;
 
 class EnvelopingEventEmitter extends EventEmitter {
   registerEventListener(
-    eventType: Event,
-    eventHandle: (...args: unknown[]) => void
+    eventHandler: (event: Event, ...args: unknown[]) => void
   ) {
-    this.on(eventType, eventHandle);
+    this.on('enveloping', eventHandler);
   }
 
   unregisterEventListener(
-    eventType: Event,
-    eventHandle: (...args: unknown[]) => void
+    eventHandler: (event: Event, ...args: unknown[]) => void
   ) {
-    this.off(eventType, eventHandle);
+    this.off('enveloping', eventHandler);
   }
 
   override emit(eventName: Event, ...args: unknown[]): boolean {
-    return super.emit(eventName, args);
+    return super.emit('enveloping', eventName, ...args);
   }
 }
 

--- a/src/events/EnvelopingEventEmitter.ts
+++ b/src/events/EnvelopingEventEmitter.ts
@@ -1,5 +1,7 @@
 import EventEmitter from 'events';
 
+const EVENT_WRAPPER = 'enveloping';
+
 const events = {
   init: 'init',
   'refresh-relays': 'refresh-relays', // TODO validate if its needed, since we do not refresh relays anymore
@@ -17,17 +19,17 @@ class EnvelopingEventEmitter extends EventEmitter {
   registerEventListener(
     eventHandler: (event: Event, ...args: unknown[]) => void
   ) {
-    this.on('enveloping', eventHandler);
+    this.on(EVENT_WRAPPER, eventHandler);
   }
 
   unregisterEventListener(
     eventHandler: (event: Event, ...args: unknown[]) => void
   ) {
-    this.off('enveloping', eventHandler);
+    this.off(EVENT_WRAPPER, eventHandler);
   }
 
   override emit(eventName: Event, ...args: unknown[]): boolean {
-    return super.emit('enveloping', eventName, ...args);
+    return super.emit(EVENT_WRAPPER, eventName, ...args);
   }
 }
 

--- a/src/events/EnvelopingEventEmitter.ts
+++ b/src/events/EnvelopingEventEmitter.ts
@@ -2,15 +2,24 @@ import EventEmitter from 'events';
 
 const EVENT_WRAPPER = 'enveloping';
 
+export const EVENT_INIT = 'init';
+export const EVENT_REFRESH_RELAYS = 'refresh-relays';
+export const EVENT_REFRESHED_RELAYS = 'refreshed-relays';
+export const EVENT_NEXT_RELAY = 'next-relay';
+export const EVENT_SIGN_REQUEST = 'sign-request';
+export const EVENT_VALIDATE_REQUEST = 'validate-request';
+export const EVENT_SEND_TO_RELAYER = 'send-to-relayer';
+export const EVENT_RELAYER_RESPONSE = 'relayer-response';
+
 const events = {
-  init: 'init',
-  'refresh-relays': 'refresh-relays', // TODO validate if its needed, since we do not refresh relays anymore
-  'refreshed-relays': 'refreshed-relays', // TODO validate if its needed, since we do not refresh relays anymore
-  'next-relay': 'next-relay',
-  'sign-request': 'sign-request',
-  'validate-request': 'validate-request',
-  'send-to-relayer': 'send-to-relayer',
-  'relayer-response': 'relayer-response',
+  [EVENT_INIT]: EVENT_INIT,
+  [EVENT_REFRESH_RELAYS]: EVENT_REFRESH_RELAYS, // TODO validate if its needed, since we do not refresh relays anymore
+  [EVENT_REFRESHED_RELAYS]: EVENT_REFRESHED_RELAYS, // TODO validate if its needed, since we do not refresh relays anymore
+  [EVENT_NEXT_RELAY]: EVENT_NEXT_RELAY,
+  [EVENT_SIGN_REQUEST]: EVENT_SIGN_REQUEST,
+  [EVENT_VALIDATE_REQUEST]: EVENT_VALIDATE_REQUEST,
+  [EVENT_SEND_TO_RELAYER]: EVENT_SEND_TO_RELAYER,
+  [EVENT_RELAYER_RESPONSE]: EVENT_RELAYER_RESPONSE,
 } as const;
 
 type Event = keyof typeof events;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export * from './gasEstimator';
 export * from './utils';
 export * from './common';
 export * from './typedRequestData.utils';
+export * from './events/EnvelopingEventEmitter';
 
 export { AccountManager, RelayPricer, RelayClient };

--- a/test/RelayClient.test.ts
+++ b/test/RelayClient.test.ts
@@ -56,7 +56,9 @@ import {
   NOT_RELAYED_TRANSACTION,
 } from '../src/constants/errorMessages';
 import EnvelopingEventEmitter, {
-  envelopingEvents,
+  EVENT_SEND_TO_RELAYER,
+  EVENT_SIGN_REQUEST,
+  EVENT_VALIDATE_REQUEST,
 } from '../src/events/EnvelopingEventEmitter';
 import RelayClient from '../src/RelayClient';
 import { FAKE_ENVELOPING_CONFIG } from './config.fakes';
@@ -342,7 +344,7 @@ describe('RelayClient', function () {
         expect(signStub).to.have.been.calledWith(expectedRelayRequestData);
       });
 
-      it(`should emit sign request 'sign-request' `, async function () {
+      it(`should emit sign request '${EVENT_SIGN_REQUEST}'`, async function () {
         const emitStub = sandbox.stub();
         (relayClient as unknown as EnvelopingEventEmitter).emit = emitStub;
         await relayClient._prepareHttpRequest(
@@ -351,9 +353,7 @@ describe('RelayClient', function () {
         );
 
         expect(emitStub).to.have.been.called;
-        expect(emitStub).to.have.been.calledWith(
-          envelopingEvents['sign-request']
-        );
+        expect(emitStub).to.have.been.calledWith(EVENT_SIGN_REQUEST);
       });
 
       it('should return relay metadata with signature from account manager', async function () {
@@ -1229,7 +1229,7 @@ describe('RelayClient', function () {
         expect(attempRelay).to.be.undefined;
       });
 
-      it(`should emit 'send-to-relayer' `, async function () {
+      it(`should emit '${EVENT_SEND_TO_RELAYER}'`, async function () {
         const emitStub = sandbox.stub();
         (relayClient as unknown as EnvelopingEventEmitter).emit = emitStub;
         await relayClient._attemptRelayTransaction(
@@ -1238,9 +1238,7 @@ describe('RelayClient', function () {
         );
 
         expect(emitStub).to.have.been.called;
-        expect(emitStub).to.have.been.calledWith(
-          envelopingEvents['send-to-relayer']
-        );
+        expect(emitStub).to.have.been.calledWith(EVENT_SEND_TO_RELAYER);
       });
     });
 
@@ -1350,7 +1348,7 @@ describe('RelayClient', function () {
         await expect(verification).to.be.rejectedWith(error.message);
       });
 
-      it(`should emit 'validate-request' `, async function () {
+      it(`should emit '${EVENT_VALIDATE_REQUEST}' `, async function () {
         const emitStub = sandbox.stub();
         (relayClient as unknown as EnvelopingEventEmitter).emit = emitStub;
         await relayClient._verifyEnvelopingRequest(
@@ -1359,9 +1357,7 @@ describe('RelayClient', function () {
         );
 
         expect(emitStub).to.have.been.called;
-        expect(emitStub).to.have.been.calledWith(
-          envelopingEvents['validate-request']
-        );
+        expect(emitStub).to.have.been.calledWith(EVENT_VALIDATE_REQUEST);
       });
     });
 


### PR DESCRIPTION
## What

- Update the relay-client constructor to receive a http client
- Update the event registration and unregistration

## Why

- Part of the relay-client integration tests migration

## Refs

- [PP-635](https://rsklabs.atlassian.net/browse/PP-635)
