### PR TITLE
PP-754: make the readonly properties public to allow developers to use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "private": false,
   "description": "This project contains all the client code for the rif relay system.",
   "license": "MIT",

--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -90,6 +90,10 @@ class RelayClient extends EnvelopingEventEmitter {
     this._httpClient = httpClient;
   }
 
+  public get httpClient(): HttpClient {
+    return this._httpClient;
+  }
+
   private _getEnvelopingRequestDetails = async (
     envelopingRequest: UserDefinedEnvelopingRequest
   ): Promise<EnvelopingRequest> => {

--- a/src/api/common/HttpClient.ts
+++ b/src/api/common/HttpClient.ts
@@ -40,6 +40,10 @@ class HttpClient {
     this._httpWrapper = httpWrapper;
   }
 
+  public get httpWrapper(): HttpWrapper {
+    return this._httpWrapper;
+  }
+
   async getChainInfo(relayUrl: string, verifier = ''): Promise<HubInfo> {
     const url = buildUrl(relayUrl, PATHS.CHAIN_INFO, verifier);
 

--- a/src/api/common/HttpWrapper.ts
+++ b/src/api/common/HttpWrapper.ts
@@ -78,6 +78,10 @@ export default class HttpWrapper {
     logger.setLevel(logLevel);
   }
 
+  public get httpClient() {
+    return this._httpClient;
+  }
+
   async sendPromise<T>(url: string, jsonRequestData?: unknown) {
     logger.info(
       'Sending request:',

--- a/test/RelayClient.test.ts
+++ b/test/RelayClient.test.ts
@@ -1680,4 +1680,12 @@ describe('RelayClient', function () {
       });
     });
   });
+
+  describe('properties', function() {
+    it('should expose the `httpClient` property', function () {
+      const relayClient = new RelayClient();
+
+      expect(relayClient.httpClient).not.to.be.undefined;
+    })
+  })
 });

--- a/test/RelayClient.test.ts
+++ b/test/RelayClient.test.ts
@@ -1681,11 +1681,11 @@ describe('RelayClient', function () {
     });
   });
 
-  describe('properties', function() {
+  describe('properties', function () {
     it('should expose the `httpClient` property', function () {
       const relayClient = new RelayClient();
 
       expect(relayClient.httpClient).not.to.be.undefined;
-    })
-  })
+    });
+  });
 });

--- a/test/api/common/HttpClient.test.ts
+++ b/test/api/common/HttpClient.test.ts
@@ -259,4 +259,12 @@ describe('HttpClient', function () {
       expect(url).to.be.equal(expected);
     });
   });
+
+  describe('properties', function() {
+    it('should expose the `httpWrapper` property', function () {
+      const httpClient = new HttpClient();
+      
+      expect(httpClient.httpWrapper).not.to.be.undefined;
+    })
+  })
 });

--- a/test/api/common/HttpClient.test.ts
+++ b/test/api/common/HttpClient.test.ts
@@ -260,11 +260,11 @@ describe('HttpClient', function () {
     });
   });
 
-  describe('properties', function() {
+  describe('properties', function () {
     it('should expose the `httpWrapper` property', function () {
       const httpClient = new HttpClient();
-      
+
       expect(httpClient.httpWrapper).not.to.be.undefined;
-    })
-  })
+    });
+  });
 });

--- a/test/api/common/HttpWrapper.test.ts
+++ b/test/api/common/HttpWrapper.test.ts
@@ -131,4 +131,12 @@ describe('HttpWrapper', function () {
       });
     });
   });
+
+  describe('properties', function() {
+    it('should expose `httpClient`', function () {
+      const httpWrapper = new HttpWrapper();
+
+      expect(httpWrapper.httpClient).not.to.be.undefined;
+    })
+  })
 });

--- a/test/api/common/HttpWrapper.test.ts
+++ b/test/api/common/HttpWrapper.test.ts
@@ -132,11 +132,11 @@ describe('HttpWrapper', function () {
     });
   });
 
-  describe('properties', function() {
+  describe('properties', function () {
     it('should expose `httpClient`', function () {
       const httpWrapper = new HttpWrapper();
 
       expect(httpWrapper.httpClient).not.to.be.undefined;
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
## What

- Change the relayClient to expose the httpClient
- Change the httpClient to expose the httpWrapper
- Change the httpWrapper to expose the superAgent instance

## Why

- It would allow developers to customize the requests as they want (e.g.: set request headers)
