### PR TITLE
fix: use the feesReceiver to estimate native payment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": false,
   "description": "This project contains all the client code for the rif relay system.",
   "license": "MIT",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,8 +115,13 @@ const estimatePaymentGas = async ({
   const isNativePayment = (await tokenContract) === constants.AddressZero;
 
   if (isNativePayment) {
+    // Ideally we should set `from` with the tokenOrigin address,
+    // but the tokenOrigin may not have funds, hence the estimation will fail
+    // so we set the feesReceiver as the `from` address.
+    // This may be wrong in case the feesReceiver performs some operations using
+    // the msg.sender address in the fallback/receive function.
     return await estimateInternalCallGas({
-      from: tokenOrigin,
+      from: feesReceiver,
       to: feesReceiver,
       gasPrice,
       value: tokenAmount,


### PR DESCRIPTION
## What

- estimate the native payment using the feesReceiver

## Why

- using the tokenOrigin makes the estimation fail since the tokenOrigin doesn't have funds
