### PR TITLE
feat: boltz verifier claim swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@rsksmart/rif-relay-contracts": "github:rsksmart/rif-relay-contracts#boltz-verifier-claim-amount",
+    "@rsksmart/rif-relay-contracts": "^2.1.1-beta.0",
     "ethers": "^5.7.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": false,
   "description": "This project contains all the client code for the rif relay system.",
   "license": "MIT",
@@ -90,7 +90,7 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@rsksmart/rif-relay-contracts": "^2.1.0-beta.0",
+    "@rsksmart/rif-relay-contracts": "github:rsksmart/rif-relay-contracts#boltz-verifier-claim-amount",
     "ethers": "^5.7.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## What

- Boltz verifier validates claiming amount in native payment

## Why

- To avoid executing a relay tx that cannot cover the payment

## Refs

- https://github.com/rsksmart/rif-relay-contracts/pull/165
