### PR TITLE
fix: nonce from worker signer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-client",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "private": false,
   "description": "This project contains all the client code for the rif relay system.",
   "license": "MIT",
@@ -90,7 +90,7 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@rsksmart/rif-relay-contracts": "2.1.1-beta.1",
+    "@rsksmart/rif-relay-contracts": "2.1.1-beta.2",
     "ethers": "^5.7.0"
   },
   "publishConfig": {

--- a/src/gasEstimator/gasEstimator.ts
+++ b/src/gasEstimator/gasEstimator.ts
@@ -76,7 +76,7 @@ const estimateRelayMaxPossibleGas = async (
  *      the costs are included in all of them. These costs can be subtract by using the following constants:
  *      - POST_RELAY_DEPLOY_GAS_COST: transfer back cost is always included since we cannot know if the smart wallet is going
  *        to have some balance after the execution
- *      - OWNER_ALREADY_TOUCHED: Owner already touched, while we are doing the transfer back the owner may or not be a new account
+ *      - OWNER_ALREADY_TOUCHED: Owner already touched, the owner of the smart wallet was previously touched
  * @param relayRequest
  * @param signer
  * @param options

--- a/src/gasEstimator/gasEstimator.ts
+++ b/src/gasEstimator/gasEstimator.ts
@@ -5,16 +5,21 @@ import type { EnvelopingTxRequest } from '../common/relayTransaction.types';
 import {
   POST_RELAY_DEPLOY_GAS_COST,
   PRE_RELAY_GAS_COST,
-  POST_DEPLOY_EXECUTION_FACTOR,
   resolveSmartWalletAddress,
   standardMaxPossibleGasEstimation,
+  STORAGE_REFUND,
+  POST_DEPLOY_EXECUTION,
+  POST_DEPLOY_NO_EXECUTION,
 } from './utils';
 import {
   getProvider,
   type EnvelopingRequest,
   type RelayTxOptions,
 } from '../common';
-import { RelayHub__factory } from '@rsksmart/rif-relay-contracts';
+import {
+  BaseSmartWalletFactory__factory,
+  RelayHub__factory,
+} from '@rsksmart/rif-relay-contracts';
 import { signEnvelopingRequest } from '../signer';
 
 const estimateRelayMaxPossibleGas = async (
@@ -63,10 +68,15 @@ const estimateRelayMaxPossibleGas = async (
  *    - preEnvelopedTxEstimation: the gas required without the payment and the internal call
  *    - paymentEstimation: the gas required for the payment
  *    - internalEstimation: the gas required for the internal call
- *    - POST_DEPLOY_NO_EXECUTION: when there is no execution in deployment, an additional 4_000 are needed. In the default
- *      we need to subtract 3500 to avoid over estimating the tx
- *    - POST_RELAY_DEPLOY_GAS_COST: transfer back cost is always included since we cannot know if the smart wallet is going
- *      to have some balance after the execution
+ *    - POST_DEPLOY_NO_EXECUTION: when there is no execution in deployment, an additional 4_000 are needed
+ *    - POST_DEPLOY_EXECUTION: when there is execution in deployment, an additional 1_500 are needed
+ *    - STORAGE_REFUND: After the nonces were already touched by a smart wallet deployment or smart wallet execution, we need to subtract 15_000
+ * - Manually subtract:
+ *    - Without signature, we cannot analyze if there some of the gas costs should be included or not, to avoid underestimating the relay transaction
+ *      the costs are included in all of them. These costs can be subtract by using the following constants:
+ *      - POST_RELAY_DEPLOY_GAS_COST: transfer back cost is always included since we cannot know if the smart wallet is going
+ *        to have some balance after the execution
+ *      - OWNER_ALREADY_TOUCHED: Owner already touched, while we are doing the transfer back the owner may or not be a new account
  * @param relayRequest
  * @param signer
  * @param options
@@ -96,18 +106,24 @@ const estimateRelayMaxPossibleGasNoSignature = async (
   const isDeploy = isDeployRequest(relayRequest);
   if (isDeploy) {
     const from = signer.address;
+    const provider = getProvider();
+    const factory = BaseSmartWalletFactory__factory.connect(
+      await relayRequest.relayData.callForwarder,
+      provider
+    );
+    const nonce = await factory.nonce(from);
     const updatedRelayRequest = {
       request: {
         ...relayRequest.request,
         from,
         to: constants.AddressZero,
+        nonce,
       },
       relayData: {
         ...relayRequest.relayData,
       },
     };
     const signature = signEnvelopingRequest(updatedRelayRequest, from, signer);
-    const provider = getProvider();
     const relayHub = RelayHub__factory.connect(
       await request.relayHub,
       provider
@@ -150,10 +166,15 @@ const estimateRelayMaxPossibleGasNoSignature = async (
   let missingGas = 0;
   if (isDeploy) {
     if (to == constants.AddressZero) {
-      missingGas = POST_DEPLOY_EXECUTION_FACTOR * 8;
+      missingGas = POST_DEPLOY_NO_EXECUTION;
     } else {
-      missingGas = POST_DEPLOY_EXECUTION_FACTOR * 3;
+      missingGas = POST_DEPLOY_EXECUTION;
     }
+  }
+
+  const nonce = BigNumber.from(await request.nonce);
+  if (!nonce.isZero()) {
+    missingGas -= STORAGE_REFUND;
   }
 
   return preEnvelopedTxEstimation

--- a/src/gasEstimator/gasEstimator.ts
+++ b/src/gasEstimator/gasEstimator.ts
@@ -72,11 +72,12 @@ const estimateRelayMaxPossibleGas = async (
  *    - POST_DEPLOY_EXECUTION: when there is execution in deployment, an additional 1_500 are needed
  *    - STORAGE_REFUND: After the nonces were already touched by a smart wallet deployment or smart wallet execution, we need to subtract 15_000
  * - Manually subtract:
- *    - Without signature, we cannot analyze if there some of the gas costs should be included or not, to avoid underestimating the relay transaction
+ *    - Without signature, we cannot analyze if some of the gas costs should be included or not, to avoid underestimating the relay transaction
  *      the costs are included in all of them. These costs can be subtract by using the following constants:
- *      - POST_RELAY_DEPLOY_GAS_COST: transfer back cost is always included since we cannot know if the smart wallet is going
+ *      - POST_RELAY_DEPLOY_GAS_COST: The transfer back cost is always included since we cannot know if the smart wallet is going
  *        to have some balance after the execution
- *      - OWNER_ALREADY_TOUCHED: Owner already touched, the owner of the smart wallet was previously touched
+ *      - ACCOUNT_ALREADY_CREATED: The owner address of the smart wallet was previously created. A utility function was included to check
+ *        if the owner address of smart wallet was already created
  * @param relayRequest
  * @param signer
  * @param options

--- a/src/gasEstimator/index.ts
+++ b/src/gasEstimator/index.ts
@@ -4,8 +4,8 @@ export {
 } from './gasEstimator';
 export {
   standardMaxPossibleGasEstimation,
-  touchedAccount,
+  isAccountCreated,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
-  OWNER_ALREADY_TOUCHED,
+  ACCOUNT_ALREADY_CREATED,
 } from './utils';

--- a/src/gasEstimator/index.ts
+++ b/src/gasEstimator/index.ts
@@ -6,4 +6,5 @@ export {
   standardMaxPossibleGasEstimation,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
+  OWNER_ALREADY_TOUCHED,
 } from './utils';

--- a/src/gasEstimator/index.ts
+++ b/src/gasEstimator/index.ts
@@ -4,6 +4,7 @@ export {
 } from './gasEstimator';
 export {
   standardMaxPossibleGasEstimation,
+  touchedAccount,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
   OWNER_ALREADY_TOUCHED,

--- a/src/gasEstimator/utils.ts
+++ b/src/gasEstimator/utils.ts
@@ -15,7 +15,7 @@ const POST_RELAY_DEPLOY_GAS_COST = 33_500;
 const POST_DEPLOY_EXECUTION = 1_500;
 const POST_DEPLOY_NO_EXECUTION = 4_000;
 const STORAGE_REFUND = 15_000;
-const OWNER_ALREADY_TOUCHED = 25_000;
+const ACCOUNT_ALREADY_CREATED = 25_000;
 
 const standardMaxPossibleGasEstimation = async (
   { relayRequest, metadata: { signature } }: EnvelopingTxRequest,
@@ -79,7 +79,7 @@ const resolveSmartWalletAddress = async (
     : callForwarder;
 };
 
-const touchedAccount = async (address: string) => {
+const isAccountCreated = async (address: string) => {
   const provider = getProvider();
   const ownerBalance = await provider.getBalance(address);
   const ownerTx = await provider.getTransactionCount(address);
@@ -90,11 +90,11 @@ const touchedAccount = async (address: string) => {
 export {
   standardMaxPossibleGasEstimation,
   resolveSmartWalletAddress,
-  touchedAccount,
+  isAccountCreated,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
   POST_DEPLOY_EXECUTION,
   POST_DEPLOY_NO_EXECUTION,
   STORAGE_REFUND,
-  OWNER_ALREADY_TOUCHED,
+  ACCOUNT_ALREADY_CREATED,
 };

--- a/src/gasEstimator/utils.ts
+++ b/src/gasEstimator/utils.ts
@@ -12,7 +12,10 @@ import type { RelayTxOptions } from '../common';
 
 const PRE_RELAY_GAS_COST = 74_000;
 const POST_RELAY_DEPLOY_GAS_COST = 33_500;
-const POST_DEPLOY_EXECUTION_FACTOR = 500;
+const POST_DEPLOY_EXECUTION = 1_500;
+const POST_DEPLOY_NO_EXECUTION = 4_000;
+const STORAGE_REFUND = 15_000;
+const OWNER_ALREADY_TOUCHED = 25_000;
 
 const standardMaxPossibleGasEstimation = async (
   { relayRequest, metadata: { signature } }: EnvelopingTxRequest,
@@ -81,5 +84,8 @@ export {
   resolveSmartWalletAddress,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
-  POST_DEPLOY_EXECUTION_FACTOR,
+  POST_DEPLOY_EXECUTION,
+  POST_DEPLOY_NO_EXECUTION,
+  STORAGE_REFUND,
+  OWNER_ALREADY_TOUCHED,
 };

--- a/src/gasEstimator/utils.ts
+++ b/src/gasEstimator/utils.ts
@@ -79,9 +79,18 @@ const resolveSmartWalletAddress = async (
     : callForwarder;
 };
 
+const touchedAccount = async (address: string) => {
+  const provider = getProvider();
+  const ownerBalance = await provider.getBalance(address);
+  const ownerTx = await provider.getTransactionCount(address);
+
+  return !ownerBalance.isZero() || ownerTx > 0;
+};
+
 export {
   standardMaxPossibleGasEstimation,
   resolveSmartWalletAddress,
+  touchedAccount,
   PRE_RELAY_GAS_COST,
   POST_RELAY_DEPLOY_GAS_COST,
   POST_DEPLOY_EXECUTION,

--- a/test/gasEstimator/gasEstimator.test.ts
+++ b/test/gasEstimator/gasEstimator.test.ts
@@ -24,7 +24,7 @@ import {
   PRE_RELAY_GAS_COST,
   resolveSmartWalletAddress,
   standardMaxPossibleGasEstimation,
-  touchedAccount,
+  isAccountCreated,
 } from '../../src/gasEstimator/utils';
 import { createRandomAddress } from '../utils';
 import type { EnvelopingTxRequest } from '../../src';
@@ -447,7 +447,7 @@ describe('GasEstimator', function () {
     });
   });
 
-  describe('touchedAccount', function () {
+  describe('isAccountCreated', function () {
     let providerStub: SinonStubbedInstance<providers.BaseProvider>;
 
     beforeEach(function () {
@@ -462,13 +462,13 @@ describe('GasEstimator', function () {
     });
 
     it('should return true if balance is not zero', async function () {
-      const touched = await touchedAccount(createRandomAddress());
+      const touched = await isAccountCreated(createRandomAddress());
 
       expect(touched).to.be.true;
     });
 
     it('should return true if transaction count is greater than 0', async function () {
-      const touched = await touchedAccount(createRandomAddress());
+      const touched = await isAccountCreated(createRandomAddress());
 
       expect(touched).to.be.true;
     });
@@ -477,7 +477,7 @@ describe('GasEstimator', function () {
       providerStub.getBalance.resolves(BigNumber.from(0));
       providerStub.getTransactionCount.resolves(0);
 
-      const touched = await touchedAccount(createRandomAddress());
+      const touched = await isAccountCreated(createRandomAddress());
 
       expect(touched).to.be.false;
     });

--- a/test/gasEstimator/gasEstimator.test.ts
+++ b/test/gasEstimator/gasEstimator.test.ts
@@ -3,7 +3,12 @@ import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import { createSandbox, SinonStubbedInstance } from 'sinon';
 import { BigNumber, constants, providers, Wallet } from 'ethers';
-import { RelayHub, RelayHub__factory } from '@rsksmart/rif-relay-contracts';
+import {
+  BaseSmartWalletFactory__factory,
+  RelayHub,
+  RelayHub__factory,
+  SmartWalletFactory,
+} from '@rsksmart/rif-relay-contracts';
 
 import {
   FAKE_DEPLOY_REQUEST,
@@ -47,6 +52,7 @@ describe('GasEstimator', function () {
         request: {
           ...FAKE_RELAY_TRANSACTION_REQUEST.relayRequest.request,
           tokenAmount: 0,
+          nonce: constants.Zero,
         },
       },
     };
@@ -57,6 +63,7 @@ describe('GasEstimator', function () {
         request: {
           ...FAKE_DEPLOY_TRANSACTION_REQUEST.relayRequest.request,
           tokenAmount: 0,
+          nonce: constants.Zero,
         },
       },
     };
@@ -300,7 +307,14 @@ describe('GasEstimator', function () {
           },
         } as unknown as RelayHub;
 
+        const factoryStub = {
+          nonce: () => Promise.resolve(constants.One),
+        } as unknown as SmartWalletFactory;
+
         sandbox.stub(RelayHub__factory, 'connect').returns(relayHubStub);
+        sandbox
+          .stub(BaseSmartWalletFactory__factory, 'connect')
+          .returns(factoryStub);
       });
 
       describe('with contract execution', function () {
@@ -314,7 +328,7 @@ describe('GasEstimator', function () {
             .add(fakeTokenGas)
             .add(fakeInternalGas)
             .add(gasEstimatorUtils.POST_RELAY_DEPLOY_GAS_COST)
-            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION_FACTOR * 3);
+            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION);
 
           expect(estimation).eqls(
             expectedEstimation,
@@ -338,7 +352,7 @@ describe('GasEstimator', function () {
             .add(fakeTokenGas)
             .add(fakeInternalGas)
             .add(gasEstimatorUtils.POST_RELAY_DEPLOY_GAS_COST)
-            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION_FACTOR * 3);
+            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION);
 
           expect(estimation).eqls(
             expectedEstimation,
@@ -370,7 +384,7 @@ describe('GasEstimator', function () {
           const expectedEstimation = deployEstimation
             .add(fakeTokenGas)
             .add(gasEstimatorUtils.POST_RELAY_DEPLOY_GAS_COST)
-            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION_FACTOR * 8);
+            .add(gasEstimatorUtils.POST_DEPLOY_NO_EXECUTION);
 
           expect(estimation).eqls(
             expectedEstimation,
@@ -393,7 +407,7 @@ describe('GasEstimator', function () {
           const expectedEstimation = deployEstimation
             .add(fakeTokenGas)
             .add(gasEstimatorUtils.POST_RELAY_DEPLOY_GAS_COST)
-            .add(gasEstimatorUtils.POST_DEPLOY_EXECUTION_FACTOR * 8);
+            .add(gasEstimatorUtils.POST_DEPLOY_NO_EXECUTION);
 
           expect(estimation).eqls(
             expectedEstimation,

--- a/test/gasEstimator/gasEstimator.test.ts
+++ b/test/gasEstimator/gasEstimator.test.ts
@@ -24,6 +24,7 @@ import {
   PRE_RELAY_GAS_COST,
   resolveSmartWalletAddress,
   standardMaxPossibleGasEstimation,
+  touchedAccount,
 } from '../../src/gasEstimator/utils';
 import { createRandomAddress } from '../utils';
 import type { EnvelopingTxRequest } from '../../src';
@@ -443,6 +444,42 @@ describe('GasEstimator', function () {
       );
 
       expect(smartWalletAddress).to.be.equal(expectedSmartWalletAddress);
+    });
+  });
+
+  describe('touchedAccount', function () {
+    let providerStub: SinonStubbedInstance<providers.BaseProvider>;
+
+    beforeEach(function () {
+      providerStub = sandbox.createStubInstance(providers.BaseProvider);
+      sandbox.stub(clientConfiguration, 'getProvider').returns(providerStub);
+      providerStub.getBalance.resolves(BigNumber.from(1));
+      providerStub.getTransactionCount.resolves(1);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should return true if balance is not zero', async function () {
+      const touched = await touchedAccount(createRandomAddress());
+
+      expect(touched).to.be.true;
+    });
+
+    it('should return true if transaction count is greater than 0', async function () {
+      const touched = await touchedAccount(createRandomAddress());
+
+      expect(touched).to.be.true;
+    });
+
+    it('should return false if balance is zero and transaction count is 0', async function () {
+      providerStub.getBalance.resolves(BigNumber.from(0));
+      providerStub.getTransactionCount.resolves(0);
+
+      const touched = await touchedAccount(createRandomAddress());
+
+      expect(touched).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## What

- Additional gas cost for touched accounts or storage

## Why

- After the owner already interacted with RIF Relay there are some storage that are touched, this storage needs cost to be subtracted from the request

