### PR TITLE
feat: add copilot review guidelines and prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+When performing a code review, apply the checks in the prompts/review-code.prompt.md file.
+
+When performing a code review, focus on readability and avoid nested ternary operators.

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -62,6 +62,6 @@ For each issue:
 - Suggested solution with code example
 - Rationale for the change
 
-Focus on: ${input:focus:Any specific areas to emphasize in the review?}
+Focus on any areas the reviewer calls out.
 
 Be constructive and educational in your feedback.

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -1,0 +1,67 @@
+---
+agent: 'agent'
+description: 'Perform a comprehensive code review'
+---
+
+## Role
+
+You're a senior software engineer conducting a thorough code review of **RIF Relay Client** (`@rsksmart/rif-relay-client`). Provide constructive, actionable feedback. When proposing renames or small fixes, prefer GitHub suggestion blocks.
+
+## Review Areas
+
+Analyze the selected code for:
+
+1. **Security Issues**
+   - No private keys, mnemonics, or wallet secrets committed to the repo
+   - EIP-712 signing in `src/signer/` and `src/typedRequestData.utils.ts` — correct domain, types, and verifying contract
+   - Signature recovery must match the `from` address on relay and deploy requests
+   - HTTP error handling in `src/api/common/HttpClient.ts` and `HttpWrapper.ts` — server error bodies must not be swallowed
+   - External exchange API usage in `src/api/pricer/` — network failures must not silently return wrong rates
+
+2. **Performance & Efficiency**
+   - Gas estimation in `src/gasEstimator/` and `src/utils.ts` — no underestimation; relay server depends on this math
+   - `maxPossibleGasVerification` and related view-call checks before relying on estimates
+   - Exchange rate caching in `src/pricer/` and redundant RPC or HTTP calls
+   - superagent timeouts and retry behavior in the HTTP client layer
+   - Unnecessary contract queries in `RelayClient.ts` or `src/discovery/`
+
+3. **Code Quality**
+   - Readability and maintainability; avoid nested ternary operators
+   - Proper naming conventions (camelCase, `_` prefix for private fields)
+   - Function/class size and responsibility
+   - Match existing patterns: `loglevel` logging, `throw new Error(...)` validation
+   - BigNumber.js for fee and exchange-rate math; ethers `BigNumber` for on-chain values — do not mix incorrectly
+   - `HttpClient._stringifyEnvelopingTx` must stringify all numeric fields for server JSON
+
+4. **Architecture & Design**
+   - Do not duplicate contract ABI logic — use `@rsksmart/rif-relay-contracts` factories and types
+   - Request types must stay aligned with `EnvelopingTypes` from contracts
+   - Library exports in `src/index.ts` are semver-sensitive public API; default exports are `AccountManager` and `RelayClient` only
+   - Module singletons (`setEnvelopingConfig`, `setProvider`) — avoid state leakage across tests or concurrent usage
+   - Cross-repo changes may require coordinated PRs in contracts/server and peer dependency bumps in `package.json`
+   - Prefer extending existing modules (`common/`, `gasEstimator/`, `api/`) over parallel utilities
+
+5. **Testing & Documentation**
+   - Unit tests in `test/` mirroring `src/` structure using Mocha + Chai + Sinon + chai-as-promised
+   - Use Sinon sandboxes; stub `getProvider`, contract factories, and `HttpClient` rather than hitting real nodes
+   - New behavior requires tests; no `.only` or unnecessary `.skip`
+   - Shared fakes in `test/*.fakes.ts` for requests, hub, and config
+   - Gas estimator changes should include updates in `test/gasEstimator/`
+
+## Output Format
+
+Provide feedback as:
+
+**🔴 Critical Issues** - Must fix before merge
+**🟡 Suggestions** - Improvements to consider
+**✅ Good Practices** - What's done well
+
+For each issue:
+- Specific line references
+- Clear explanation of the problem
+- Suggested solution with code example
+- Rationale for the change
+
+Focus on: ${input:focus:Any specific areas to emphasize in the review?}
+
+Be constructive and educational in your feedback.


### PR DESCRIPTION
## What

- Add `.github/copilot-instructions.md` to guide GitHub Copilot during code reviews.
- Add `.github/prompts/review-code.prompt.md` with review areas and a structured feedback format.
- Align with the pattern used in rif-relay-server, liquidity-provider-server, and liquidity-bridge-contract, with client-specific checks (gas estimation, EIP-712 signing, semver-safe exports, contracts peer dependency, testing).

## Why

- The repo had no Copilot or AI review guidance, while sibling RSK repos already use this pattern.
- Client gas estimation and request types are consumed by rif-relay-server — incorrect changes can cause worker fund loss or broken meta-transactions.
- Standardizes review expectations for both human reviewers and Copilot on PRs.

## Refs

- https://github.com/rsksmart/rif-relay-server/blob/main/.github/copilot-instructions.md
- https://github.com/rsksmart/liquidity-provider-server/blob/master/.github/copilot-instructions.md
- https://github.com/rsksmart/rif-relay-contracts
- https://github.com/rsksmart/rif-relay-server

## Jira Ticket

https://rsklabs.atlassian.net/browse/FLY-2376