### PR TITLE
Chore/formatting fixes

### DIFF
--- a/src/RelayClient.ts
+++ b/src/RelayClient.ts
@@ -6,7 +6,7 @@ import {
   PromiseOrValue,
   IWalletFactory__factory,
 } from '@rsksmart/rif-relay-contracts';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import Decimal from 'bignumber.js';
 import { BigNumber, BigNumberish, constants, Transaction } from 'ethers';
 import {
   BytesLike,
@@ -414,7 +414,7 @@ class RelayClient extends EnvelopingEventEmitter {
 
     const provider = getProvider();
 
-    const networkGasPrice = new BigNumberJs(
+    const networkGasPrice = new Decimal(
       (await provider.getGasPrice()).toString()
     );
 

--- a/src/api/common/HttpWrapper.ts
+++ b/src/api/common/HttpWrapper.ts
@@ -63,7 +63,7 @@ const interceptors = {
 };
 
 export default class HttpWrapper {
-  private readonly _httpClient;
+  private readonly _httpClient: SuperAgent.SuperAgentStatic;
 
   private timeout;
 
@@ -78,7 +78,7 @@ export default class HttpWrapper {
     logger.setLevel(logLevel);
   }
 
-  public get httpClient() {
+  public get httpClient(): SuperAgent.SuperAgentStatic {
     return this._httpClient;
   }
 

--- a/src/api/pricer/BaseExchangeApi.ts
+++ b/src/api/pricer/BaseExchangeApi.ts
@@ -1,4 +1,4 @@
-import type { BigNumber as BigNumberJs } from 'bignumber.js';
+import type BigNumberJs from 'bignumber.js';
 
 export type BaseCurrency = 'TRIF' | 'RIF' | 'RDOC' | 'RBTC' | 'TKN' | 'USDRIF';
 

--- a/src/api/pricer/CoinBase.ts
+++ b/src/api/pricer/CoinBase.ts
@@ -1,5 +1,5 @@
 import type { ResponseError } from 'superagent';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import BaseExchangeApi from './BaseExchangeApi';
 import HttpWrapper from '../common/HttpWrapper';
 

--- a/src/api/pricer/CoinCodex.ts
+++ b/src/api/pricer/CoinCodex.ts
@@ -1,5 +1,5 @@
 import type { ResponseError } from 'superagent';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import BaseExchangeApi from './BaseExchangeApi';
 import HttpWrapper from '../common/HttpWrapper';
 

--- a/src/api/pricer/CoinGecko.ts
+++ b/src/api/pricer/CoinGecko.ts
@@ -1,5 +1,5 @@
 import type { ResponseError } from 'superagent';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import BaseExchangeApi, { CurrencyMapping } from './BaseExchangeApi';
 import HttpWrapper from '../common/HttpWrapper';
 

--- a/src/api/pricer/ExchangeApiCache.ts
+++ b/src/api/pricer/ExchangeApiCache.ts
@@ -1,6 +1,6 @@
 import log from 'loglevel';
 import type { ExchangeApi } from './BaseExchangeApi';
-import type { BigNumber as BigNumberJs } from 'bignumber.js';
+import type BigNumberJs from 'bignumber.js';
 
 export type RateWithExpiration = {
   rate: BigNumberJs;

--- a/src/api/pricer/StableCoinExchange.ts
+++ b/src/api/pricer/StableCoinExchange.ts
@@ -1,4 +1,4 @@
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import BaseExchangeApi, { CurrencyMapping } from './BaseExchangeApi';
 
 export type RateRecord = Record<string, string>;

--- a/src/api/pricer/TestExchange.ts
+++ b/src/api/pricer/TestExchange.ts
@@ -1,4 +1,4 @@
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import BaseExchangeApi, { CurrencyMapping } from './BaseExchangeApi';
 
 type RateRecord = Record<string, string>;

--- a/src/gasEstimator/utils.ts
+++ b/src/gasEstimator/utils.ts
@@ -66,17 +66,23 @@ const resolveSmartWalletAddress = async (
   const isSmartWalletDeploy = isDeployRequest(relayRequest);
   const isCustom = options?.isCustom;
 
-  return isSmartWalletDeploy
-    ? await getSmartWalletAddress({
-        owner: await from,
-        smartWalletIndex: smartWalletIndex!,
-        recoverer: await recoverer,
-        to: await to,
-        data: await data,
-        factoryAddress: callForwarder,
-        isCustom,
-      })
-    : callForwarder;
+  if (!isSmartWalletDeploy) {
+    return callForwarder;
+  }
+
+  if (smartWalletIndex === undefined) {
+    throw new Error('Deploy request is missing smart wallet index');
+  }
+
+  return await getSmartWalletAddress({
+    owner: await from,
+    smartWalletIndex,
+    recoverer: await recoverer,
+    to: await to,
+    data: await data,
+    factoryAddress: callForwarder,
+    isCustom,
+  });
 };
 
 const isAccountCreated = async (address: string) => {

--- a/src/pricer/pricer.ts
+++ b/src/pricer/pricer.ts
@@ -1,4 +1,4 @@
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 import log from 'loglevel';
 import {
   ExchangeApiName,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import {
   utils,
   PopulatedTransaction,
 } from 'ethers';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import Decimal from 'bignumber.js';
 import {
   ICustomSmartWalletFactory__factory,
   IERC20__factory,
@@ -281,8 +281,8 @@ const applyGasCorrectionFactor = (
   esimatedGasCorrectFactor: BigNumberish = ESTIMATED_GAS_CORRECTION_FACTOR
 ): BigNumber => {
   if (esimatedGasCorrectFactor.toString() !== '1') {
-    const bigGasCorrection = BigNumberJs(esimatedGasCorrectFactor.toString());
-    let bigEstimation = BigNumberJs(estimation.toString());
+    const bigGasCorrection = Decimal(esimatedGasCorrectFactor.toString());
+    let bigEstimation = Decimal(estimation.toString());
     bigEstimation = bigEstimation.multipliedBy(bigGasCorrection);
 
     return BigNumber.from(bigEstimation.toFixed());
@@ -449,12 +449,12 @@ const maxPossibleGasVerification = async (
 };
 
 const applyFactor = (value: BigNumberish, factor: number) => {
-  const bigFactor = BigNumberJs(1).plus(factor);
+  const bigFactor = Decimal(1).plus(factor);
 
   return BigNumber.from(
     bigFactor
       .multipliedBy(value.toString())
-      .dp(0, BigNumberJs.ROUND_DOWN)
+      .dp(0, Decimal.ROUND_DOWN)
       .toString()
   );
 };

--- a/test/api/pricer/CoinBase.test.ts
+++ b/test/api/pricer/CoinBase.test.ts
@@ -4,36 +4,41 @@ import { HttpWrapper } from '../../../src/api/common';
 
 import CoinBase, { CoinBaseResponse } from '../../../src/api/pricer/CoinBase';
 
+type CoinBaseWithProtected = {
+  _getCurrencyName(tokenSymbol: string): string;
+};
+
 describe('CoinBase', function () {
-  type CoinBaseExposed = {
-    _getCurrencyName(tokenSymbol: string): string;
-  } & {
-    [key in keyof CoinBase]: CoinBase[key];
-  };
-  let coinBase: CoinBaseExposed;
+  let coinBase: CoinBase;
+  let coinBaseWithProtected: CoinBaseWithProtected;
   const sourceCurrency = 'RIF';
   const targetCurrency = 'USD';
   const xRateRifUsd = '0.07770028890144696';
 
   beforeEach(function () {
-    coinBase = new CoinBase() as unknown as CoinBaseExposed;
+    coinBase = new CoinBase();
+    coinBaseWithProtected = coinBase as unknown as CoinBaseWithProtected;
   });
 
   describe('_getCurrencyName', function () {
     it('should return mapped token name', function () {
-      expect(coinBase._getCurrencyName('RIF')).to.be.equal(sourceCurrency);
+      expect(coinBaseWithProtected._getCurrencyName('RIF')).to.be.equal(
+        sourceCurrency
+      );
     });
 
     it('should return mapped token(lowercase) name', function () {
-      expect(coinBase._getCurrencyName('rif')).to.be.equal(sourceCurrency);
+      expect(coinBaseWithProtected._getCurrencyName('rif')).to.be.equal(
+        sourceCurrency
+      );
     });
 
     it('should return token if token is not mapped', function () {
-      expect(coinBase._getCurrencyName('btc')).to.be.equal('btc');
+      expect(coinBaseWithProtected._getCurrencyName('btc')).to.be.equal('btc');
     });
 
     it('should fail if token symbol is empty', function () {
-      expect(() => coinBase._getCurrencyName('')).to.throw(
+      expect(() => coinBaseWithProtected._getCurrencyName('')).to.throw(
         'CoinBase API cannot map a token with a null/empty value'
       );
     });

--- a/test/api/pricer/CoinCodex.test.ts
+++ b/test/api/pricer/CoinCodex.test.ts
@@ -6,36 +6,41 @@ import CoinCodex, {
   CoinCodexResponse,
 } from '../../../src/api/pricer/CoinCodex';
 
+type CoinCodexWithProtected = {
+  _getCurrencyName(tokenSymbol: string): string;
+};
+
 describe('CoinCodex', function () {
-  type CoinCodexExposed = {
-    _getCurrencyName(tokenSymbol: string): string;
-  } & {
-    [key in keyof CoinCodex]: CoinCodex[key];
-  };
-  let coinCodex: CoinCodexExposed;
+  let coinCodex: CoinCodex;
+  let coinCodexWithProtected: CoinCodexWithProtected;
   const sourceCurrency = 'RIF';
   const targetCurrency = 'USD';
   const xRateRifUsd = '0.07770028890144696';
 
   beforeEach(function () {
-    coinCodex = new CoinCodex() as unknown as CoinCodexExposed;
+    coinCodex = new CoinCodex();
+    coinCodexWithProtected = coinCodex as unknown as CoinCodexWithProtected;
   });
 
   describe('_getCurrencyName', function () {
     it('should return mapped token name', function () {
-      expect(coinCodex._getCurrencyName('RIF')).to.be.equal(sourceCurrency);
+      expect(coinCodexWithProtected._getCurrencyName('RIF')).to.be.equal(
+        sourceCurrency
+      );
     });
 
     it('should return mapped token(lowercase) name', function () {
-      expect(coinCodex._getCurrencyName('rif')).to.be.equal(sourceCurrency);
+      expect(coinCodexWithProtected._getCurrencyName('rif')).to.be.equal(
+        sourceCurrency
+      );
     });
 
     it('should return token if token is not mapped', function () {
-      expect(coinCodex._getCurrencyName('btc')).to.be.equal('btc');
+      expect(coinCodexWithProtected._getCurrencyName('btc')).to.be.equal('btc');
     });
 
     it('should fail if token symbol is empty', function () {
-      expect(() => coinCodex._getCurrencyName('')).to.throw(
+      expect(() => coinCodexWithProtected._getCurrencyName('')).to.throw(
         'CoinCodex API cannot map a token with a null/empty value'
       );
     });

--- a/test/api/pricer/CoinGecko.test.ts
+++ b/test/api/pricer/CoinGecko.test.ts
@@ -11,30 +11,31 @@ import CoinGecko, {
 
 use(chaiAsPromised);
 
+type CoinGeckoWithProtected = {
+  _getCurrencyName(tokenSymbol: string): string;
+};
+
 describe('CoinGecko', function () {
-  type CoinGeckoExposed = {
-    _getCurrencyName(tokenSymbol: string): string;
-  } & {
-    [key in keyof CoinGecko]: CoinGecko[key];
-  };
-  let coinGecko: CoinGeckoExposed;
+  let coinGecko: CoinGecko;
+  let coinGeckoWithProtected: CoinGeckoWithProtected;
   const targetCurrency = 'USD';
   const xRateRifUsd = '0.07770028890144696';
 
   beforeEach(function () {
-    coinGecko = new CoinGecko() as unknown as CoinGeckoExposed;
+    coinGecko = new CoinGecko();
+    coinGeckoWithProtected = coinGecko as unknown as CoinGeckoWithProtected;
   });
 
   describe('_getCurrencyName', function () {
     describe('using RIF', function () {
       it('should return mapped token name', function () {
-        expect(coinGecko._getCurrencyName('RIF')).to.be.equal(
+        expect(coinGeckoWithProtected._getCurrencyName('RIF')).to.be.equal(
           COINGECKO_RIF_TOKEN_ID
         );
       });
 
       it('should return mapped token(lowercase) name', function () {
-        expect(coinGecko._getCurrencyName('rif')).to.be.equal(
+        expect(coinGeckoWithProtected._getCurrencyName('rif')).to.be.equal(
           COINGECKO_RIF_TOKEN_ID
         );
       });
@@ -42,24 +43,24 @@ describe('CoinGecko', function () {
 
     describe('using RBTC', function () {
       it('should return mapped token name', function () {
-        expect(coinGecko._getCurrencyName('RBTC')).to.be.equal(
+        expect(coinGeckoWithProtected._getCurrencyName('RBTC')).to.be.equal(
           COINGECKO_RBTC_ID
         );
       });
 
       it('should return mapped token(lowercase) name', function () {
-        expect(coinGecko._getCurrencyName('rbtc')).to.be.equal(
+        expect(coinGeckoWithProtected._getCurrencyName('rbtc')).to.be.equal(
           COINGECKO_RBTC_ID
         );
       });
     });
 
     it('should return token if token is not mapped', function () {
-      expect(coinGecko._getCurrencyName('btc')).to.be.equal('btc');
+      expect(coinGeckoWithProtected._getCurrencyName('btc')).to.be.equal('btc');
     });
 
     it('should fail if token symbol is empty', function () {
-      expect(() => coinGecko._getCurrencyName('')).to.throw(
+      expect(() => coinGeckoWithProtected._getCurrencyName('')).to.throw(
         'CoinGecko API cannot map a token with a null/empty value'
       );
     });

--- a/test/api/pricer/RdocExchange.test.ts
+++ b/test/api/pricer/RdocExchange.test.ts
@@ -1,40 +1,44 @@
 import { expect } from 'chai';
 import RdocExchange from '../../../src/api/pricer/RdocExchange';
 
+type RdocExchangeWithProtected = {
+  _getCurrencyName(tokenSymbol: string): string;
+};
+
 describe('RdocExchange', function () {
-  type RdocExchangeExposed = {
-    _getCurrencyName(tokenSymbol: string): string;
-  } & {
-    [key in keyof RdocExchange]: RdocExchange[key];
-  };
-  let rdocExchange: RdocExchangeExposed;
+  let rdocExchange: RdocExchange;
+  let rdocExchangeWithProtected: RdocExchangeWithProtected;
   const SOURCE_CURRENCY = 'RDOC';
   const TARGET_CURRENCY = 'USD';
   const X_RATE_RDOC_USD = '1';
 
   beforeEach(function () {
-    rdocExchange = new RdocExchange() as unknown as RdocExchangeExposed;
+    rdocExchange = new RdocExchange();
+    rdocExchangeWithProtected =
+      rdocExchange as unknown as RdocExchangeWithProtected;
   });
 
   describe('_getCurrencyName', function () {
     it('should return mapped token name', function () {
-      expect(rdocExchange._getCurrencyName('RDOC')).to.be.equal(
+      expect(rdocExchangeWithProtected._getCurrencyName('RDOC')).to.be.equal(
         SOURCE_CURRENCY
       );
     });
 
     it('should return mapped token(lowercase) name', function () {
-      expect(rdocExchange._getCurrencyName('rdoc')).to.be.equal(
+      expect(rdocExchangeWithProtected._getCurrencyName('rdoc')).to.be.equal(
         SOURCE_CURRENCY
       );
     });
 
     it('should return token if token is not mapped', function () {
-      expect(rdocExchange._getCurrencyName('btc')).to.be.equal('btc');
+      expect(rdocExchangeWithProtected._getCurrencyName('btc')).to.be.equal(
+        'btc'
+      );
     });
 
     it('should fail if token symbol is empty', function () {
-      expect(() => rdocExchange._getCurrencyName('')).to.throw(
+      expect(() => rdocExchangeWithProtected._getCurrencyName('')).to.throw(
         'RDocExchange API cannot map a token with a null/empty value'
       );
     });

--- a/test/api/pricer/USDRIFExchange.test.ts
+++ b/test/api/pricer/USDRIFExchange.test.ts
@@ -1,40 +1,44 @@
 import { expect } from 'chai';
 import USDRIFExchange from '../../../src/api/pricer/USDRIFExchange';
 
+type USDRIFExchangeWithProtected = {
+  _getCurrencyName(tokenSymbol: string): string;
+};
+
 describe('USDRIFExchange', function () {
-  type USDRIFExchangeExposed = {
-    _getCurrencyName(tokenSymbol: string): string;
-  } & {
-    [key in keyof USDRIFExchange]: USDRIFExchange[key];
-  };
-  let rdocExchange: USDRIFExchangeExposed;
+  let usdrifExchange: USDRIFExchange;
+  let usdrifExchangeWithProtected: USDRIFExchangeWithProtected;
   const SOURCE_CURRENCY = 'USDRIF';
   const TARGET_CURRENCY = 'USD';
   const X_RATE_USDRIF_USD = '1';
 
   beforeEach(function () {
-    rdocExchange = new USDRIFExchange() as unknown as USDRIFExchangeExposed;
+    usdrifExchange = new USDRIFExchange();
+    usdrifExchangeWithProtected =
+      usdrifExchange as unknown as USDRIFExchangeWithProtected;
   });
 
   describe('_getCurrencyName', function () {
     it('should return mapped token name', function () {
-      expect(rdocExchange._getCurrencyName('USDRIF')).to.be.equal(
-        SOURCE_CURRENCY
-      );
+      expect(
+        usdrifExchangeWithProtected._getCurrencyName('USDRIF')
+      ).to.be.equal(SOURCE_CURRENCY);
     });
 
     it('should return mapped token(lowercase) name', function () {
-      expect(rdocExchange._getCurrencyName('usdrif')).to.be.equal(
-        SOURCE_CURRENCY
-      );
+      expect(
+        usdrifExchangeWithProtected._getCurrencyName('usdrif')
+      ).to.be.equal(SOURCE_CURRENCY);
     });
 
     it('should return token if token is not mapped', function () {
-      expect(rdocExchange._getCurrencyName('btc')).to.be.equal('btc');
+      expect(usdrifExchangeWithProtected._getCurrencyName('btc')).to.be.equal(
+        'btc'
+      );
     });
 
     it('should fail if token symbol is empty', function () {
-      expect(() => rdocExchange._getCurrencyName('')).to.throw(
+      expect(() => usdrifExchangeWithProtected._getCurrencyName('')).to.throw(
         'UsdRifExchange API cannot map a token with a null/empty value'
       );
     });
@@ -42,7 +46,7 @@ describe('USDRIFExchange', function () {
 
   describe('queryExchangeRate', function () {
     it('should return exchange rate USDRIF/USD', async function () {
-      const exchangeRate = await rdocExchange.queryExchangeRate(
+      const exchangeRate = await usdrifExchange.queryExchangeRate(
         SOURCE_CURRENCY,
         TARGET_CURRENCY
       );
@@ -51,7 +55,7 @@ describe('USDRIFExchange', function () {
     });
 
     it('should return exchange rate usdrif/usd', async function () {
-      const exchangeRate = await rdocExchange.queryExchangeRate(
+      const exchangeRate = await usdrifExchange.queryExchangeRate(
         SOURCE_CURRENCY.toLowerCase(),
         TARGET_CURRENCY.toLowerCase()
       );
@@ -61,7 +65,7 @@ describe('USDRIFExchange', function () {
 
     it('should fail if rate does not exist', function () {
       expect(() =>
-        rdocExchange.queryExchangeRate(SOURCE_CURRENCY, 'NA')
+        usdrifExchange.queryExchangeRate(SOURCE_CURRENCY, 'NA')
       ).to.Throw(
         `Exchange rate for currency pair ${SOURCE_CURRENCY} / NA is not available`
       );

--- a/test/pricer/pricer.test.ts
+++ b/test/pricer/pricer.test.ts
@@ -6,7 +6,7 @@ import {
   spy,
   replace,
 } from 'sinon';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { getExchangeRate } from '../../src/pricer/pricer';
 import {
   CoinCodex,
@@ -21,18 +21,18 @@ import type { ExchangeApi } from 'src/api/pricer/BaseExchangeApi';
 describe('pricer', function () {
   describe('getExchangeRate', function () {
     let coinGeckoStub: SinonStubbedInstance<CoinGecko>;
-    let fakeRifUsd: BigNumberJs;
-    let fakeRbtcUsd: BigNumberJs;
-    let fakeRbtcRif: BigNumberJs;
-    let fakeRifRbtc: BigNumberJs;
+    let fakeRifUsd: InstanceType<typeof BigNumber>;
+    let fakeRbtcUsd: InstanceType<typeof BigNumber>;
+    let fakeRbtcRif: InstanceType<typeof BigNumber>;
+    let fakeRifRbtc: InstanceType<typeof BigNumber>;
     const RIF_SYMBOL = 'RIF';
     const RBTC_SYMBOL = 'RBTC';
     let fakeBuilder: Map<ExchangeApiName, ExchangeApi>;
 
     beforeEach(function () {
       coinGeckoStub = createStubInstance(CoinGecko);
-      fakeRifUsd = randomBigNumberJs(25000);
-      fakeRbtcUsd = randomBigNumberJs(25000);
+      fakeRifUsd = randomBigNumber(25000);
+      fakeRbtcUsd = randomBigNumber(25000);
       fakeRbtcRif = fakeRbtcUsd.dividedBy(fakeRifUsd);
       fakeRifRbtc = fakeRifUsd.dividedBy(fakeRbtcUsd);
       fakeBuilder = new Map();
@@ -50,8 +50,8 @@ describe('pricer', function () {
       restore();
     });
 
-    function randomBigNumberJs(max: number) {
-      return BigNumberJs(Math.random() * max);
+    function randomBigNumber(max: number) {
+      return BigNumber(Math.random() * max);
     }
 
     it('should return exchange rate', async function () {


### PR DESCRIPTION
## Summary
- Fix `bignumber.js` imports to use default imports so TypeScript resolves proper types instead of `any`
- Use `Decimal` alias in `RelayClient` and `utils` to avoid confusion with ethers `BigNumber`
- Add explicit SuperAgent types to `HttpWrapper`
- Refactor exchange API tests to access protected methods without breaking public method typings

## Why
Named imports from `bignumber.js` were typed as `any` under strict ESLint rules, causing pre-commit failures. No runtime behavior changes.

## Test plan
- `npm run lint`
- `npm test` 
- `npm run format`

## Jira Ticket
https://rsklabs.atlassian.net/browse/FLY-2405